### PR TITLE
chore(api): add uuid v7 helper

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -21,7 +21,8 @@
     "class-validator": "^0.15.1",
     "prisma": "^5.22.0",
     "reflect-metadata": "^0.2.2",
-    "rxjs": "^7.8.1"
+    "rxjs": "^7.8.1",
+    "uuidv7": "^0.6.3"
   },
   "devDependencies": {
     "@nestjs/cli": "^10.4.9",

--- a/apps/api/src/common/id/generate-id.ts
+++ b/apps/api/src/common/id/generate-id.ts
@@ -1,0 +1,3 @@
+import { uuidv7 } from 'uuidv7';
+
+export const generateId = (): string => uuidv7();

--- a/apps/api/src/common/id/index.ts
+++ b/apps/api/src/common/id/index.ts
@@ -1,0 +1,1 @@
+export * from './generate-id';

--- a/apps/api/src/common/index.ts
+++ b/apps/api/src/common/index.ts
@@ -1,0 +1,1 @@
+export * from './id';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       rxjs:
         specifier: ^7.8.1
         version: 7.8.2
+      uuidv7:
+        specifier: ^0.6.3
+        version: 0.6.3
     devDependencies:
       '@nestjs/cli':
         specifier: ^10.4.9
@@ -3142,6 +3145,10 @@ packages:
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
+
+  uuidv7@0.6.3:
+    resolution: {integrity: sha512-zV3eW2NlXTsun/aJ7AixxZjH/byQcH/r3J99MI0dDEkU2cJIBJxhEWUHDTpOaLPRNhebPZoeHuykYREkI9HafA==}
+    hasBin: true
 
   validator@13.15.26:
     resolution: {integrity: sha512-spH26xU080ydGggxRyR1Yhcbgx+j3y5jbNXk/8L+iRvdIEQ4uTRH2Sgf2dokud6Q4oAtsbNvJ1Ft+9xmm6IZcA==}
@@ -6668,6 +6675,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utils-merge@1.0.1: {}
+
+  uuidv7@0.6.3: {}
 
   validator@13.15.26: {}
 


### PR DESCRIPTION
## Summary
- add generateId helper based on uuidv7
- export helper from the common module entrypoint
- add uuidv7 dependency to apps/api

## Testing
- pnpm --filter @repo/api typecheck
- pnpm lint

Closes #29