### PR TITLE
chore(api): configure CORS and auth cookies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,5 @@ SMTP_FROM="Sistema de Ausencias" <no-reply@empresa.com>
 
 # CORS
 CORS_ORIGIN=http://localhost:5173
+COOKIE_SAMESITE=none
+COOKIE_SECURE=true

--- a/apps/api/src/common/auth/cookies.ts
+++ b/apps/api/src/common/auth/cookies.ts
@@ -1,0 +1,29 @@
+import type { CookieOptions } from 'express';
+import { ConfigService } from '@nestjs/config';
+
+export type AuthCookieOptions = {
+  accessToken: CookieOptions;
+  refreshToken: CookieOptions;
+};
+
+export const buildAuthCookieOptions = (
+  configService: ConfigService,
+): AuthCookieOptions => {
+  const sameSite = configService.getOrThrow<'none' | 'strict'>('COOKIE_SAMESITE');
+  const secure = configService.getOrThrow<boolean>('COOKIE_SECURE');
+
+  return {
+    accessToken: {
+      httpOnly: true,
+      secure,
+      sameSite,
+      path: '/',
+    },
+    refreshToken: {
+      httpOnly: true,
+      secure,
+      sameSite,
+      path: '/auth/refresh',
+    },
+  };
+};

--- a/apps/api/src/common/index.ts
+++ b/apps/api/src/common/index.ts
@@ -2,3 +2,4 @@ export * from './id';
 export * from './clock';
 export * from './request-id';
 export * from './errors';
+export * from './auth/cookies';

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -14,4 +14,6 @@ export const envValidationSchema = Joi.object({
   SMTP_FROM: Joi.string().required(),
   CORS_ORIGIN: Joi.string().required(),
   APP_PORT: Joi.number().port().optional(),
+  COOKIE_SAMESITE: Joi.string().valid('none', 'strict').required(),
+  COOKIE_SECURE: Joi.boolean().required(),
 }).unknown(false);

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,4 +1,5 @@
 import { Logger, ValidationPipe } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 import { NestFactory } from '@nestjs/core';
 import type { Request, Response, NextFunction } from 'express';
 
@@ -9,6 +10,7 @@ const bootstrap = async (): Promise<void> => {
   const app = await NestFactory.create(AppModule, {
     logger: new Logger(),
   });
+  const configService = app.get(ConfigService);
 
   app.useGlobalPipes(
     new ValidationPipe({
@@ -19,7 +21,13 @@ const bootstrap = async (): Promise<void> => {
   );
   app.useGlobalFilters(new HttpExceptionFilter());
 
-  const port = 3000;
+  app.enableCors({
+    origin: configService.getOrThrow<string>('CORS_ORIGIN'),
+    credentials: true,
+    methods: ['GET', 'POST', 'PATCH', 'DELETE'],
+  });
+
+  const port = configService.get<number>('APP_PORT') ?? 3000;
   app.useLogger(app.get(Logger));
   app.use((request: Request, _response: Response, next: NextFunction) => {
     const requestId = request.header(REQUEST_ID_HEADER) ?? 'unknown';


### PR DESCRIPTION
## Summary
- enable CORS with configured origin and credentials
- add cookie settings helper with SameSite/Secure options
- extend env validation and example with cookie settings

## Testing
- APP_PORT=3000 DATABASE_URL=postgresql://postgres:postgres@postgres:5432/let_me_out?schema=public JWT_SECRET=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa JWT_REFRESH_SECRET=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb JWT_EXPIRES_IN=15m JWT_REFRESH_EXPIRES_IN=7d SMTP_HOST=smtp.example.com SMTP_PORT=587 SMTP_SECURE=false SMTP_USER=user SMTP_PASS=pass SMTP_FROM=no-reply@example.com CORS_ORIGIN=http://localhost:5173 COOKIE_SAMESITE=none COOKIE_SECURE=true pnpm --filter @repo/api dev
- pnpm --filter @repo/api typecheck
- pnpm lint

Closes #34