### PR TITLE
feat(auth): add refresh endpoint

### DIFF
--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Post, Req, Res, UseGuards } from '@nestjs/common';
+import { Body, Controller, Post, Req, Res, UseGuards, UnauthorizedException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import type { Request, Response } from 'express';
 
@@ -28,6 +28,20 @@ export class AuthController {
 
     response.cookie('access_token', accessToken, cookieOptions.accessToken);
     response.cookie('refresh_token', refreshToken, cookieOptions.refreshToken);
+
+    return { success: true };
+  }
+
+  @Post('refresh')
+  async refresh(@Req() request: Request, @Res({ passthrough: true }) response: Response) {
+    const refreshToken = request.cookies?.refresh_token;
+    if (!refreshToken) {
+      throw new UnauthorizedException('Missing refresh token');
+    }
+
+    const accessToken = await this.authService.refreshAccessToken(refreshToken);
+    const cookieOptions = buildAuthCookieOptions(this.configService);
+    response.cookie('access_token', accessToken, cookieOptions.accessToken);
 
     return { success: true };
   }

--- a/apps/api/src/modules/auth/auth.service.ts
+++ b/apps/api/src/modules/auth/auth.service.ts
@@ -57,4 +57,28 @@ export class AuthService {
 
     return { accessToken, refreshToken };
   }
+
+  async refreshAccessToken(refreshToken: string): Promise<string> {
+    try {
+      const payload = await this.jwtService.verifyAsync<{ userId: string }>(refreshToken, {
+        secret: this.configService.getOrThrow<string>('JWT_REFRESH_SECRET'),
+      });
+
+      const user = await this.prismaService.user.findUnique({
+        where: { id: payload.userId },
+      });
+
+      if (!user || !user.is_active) {
+        throw new UnauthorizedException('Invalid refresh token');
+      }
+
+      return await this.jwtService.signAsync({
+        userId: user.id,
+        email: user.email,
+        role: user.role,
+      });
+    } catch {
+      throw new UnauthorizedException('Invalid refresh token');
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- add /auth/refresh endpoint to reissue access tokens
- validate refresh token and respond 401 on invalid/expired tokens

## Testing
- APP_PORT=3001 DATABASE_URL=postgresql://postgres:postgres@postgres:5432/let_me_out?schema=public JWT_SECRET=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa JWT_REFRESH_SECRET=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb JWT_EXPIRES_IN=15m JWT_REFRESH_EXPIRES_IN=7d SMTP_HOST=smtp.example.com SMTP_PORT=587 SMTP_SECURE=false SMTP_USER=user SMTP_PASS=pass SMTP_FROM=no-reply@example.com CORS_ORIGIN=http://localhost:5173 COOKIE_SAMESITE=none COOKIE_SECURE=true pnpm --filter @repo/api dev
- pnpm --filter @repo/api typecheck
- pnpm lint

Closes #37