### PR TITLE
feat(auth): add jwt and roles guards

### DIFF
--- a/apps/api/src/common/auth/public.decorator.ts
+++ b/apps/api/src/common/auth/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/apps/api/src/common/auth/roles.decorator.ts
+++ b/apps/api/src/common/auth/roles.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const ROLES_KEY = 'roles';
+export const Roles = (...roles: string[]) => SetMetadata(ROLES_KEY, roles);

--- a/apps/api/src/common/auth/roles.guard.ts
+++ b/apps/api/src/common/auth/roles.guard.ts
@@ -1,0 +1,25 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+
+import { ROLES_KEY } from './roles.decorator';
+
+@Injectable()
+export class RolesGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const requiredRoles = this.reflector.getAllAndOverride<string[]>(ROLES_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!requiredRoles || requiredRoles.length === 0) {
+      return true;
+    }
+
+    const request = context.switchToHttp().getRequest();
+    const user = request.user as { role?: string } | undefined;
+
+    return !!user?.role && requiredRoles.includes(user.role);
+  }
+}

--- a/apps/api/src/common/index.ts
+++ b/apps/api/src/common/index.ts
@@ -3,3 +3,6 @@ export * from './clock';
 export * from './request-id';
 export * from './errors';
 export * from './auth/cookies';
+export * from './auth/roles.decorator';
+export * from './auth/roles.guard';
+export * from './auth/public.decorator';

--- a/apps/api/src/modules/app.module.ts
+++ b/apps/api/src/modules/app.module.ts
@@ -1,8 +1,10 @@
 import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
+import { APP_GUARD } from '@nestjs/core';
 import { ConfigModule } from '@nestjs/config';
 
 import { PrismaModule } from '../prisma/prisma.module';
-import { ClockService, RequestIdMiddleware } from '../common';
+import { ClockService, RequestIdMiddleware, RolesGuard } from '../common';
+import { JwtAuthGuard } from '../modules/auth/guards/jwt-auth.guard';
 import { envValidationSchema } from '../config';
 import { AuthModule } from './auth';
 
@@ -15,7 +17,17 @@ import { AuthModule } from './auth';
     AuthModule,
     PrismaModule,
   ],
-  providers: [ClockService],
+  providers: [
+    ClockService,
+    {
+      provide: APP_GUARD,
+      useClass: JwtAuthGuard,
+    },
+    {
+      provide: APP_GUARD,
+      useClass: RolesGuard,
+    },
+  ],
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer): void {

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -2,7 +2,7 @@ import { Body, Controller, Post, Req, Res, UseGuards, UnauthorizedException } fr
 import { ConfigService } from '@nestjs/config';
 import type { Request, Response } from 'express';
 
-import { buildAuthCookieOptions } from '../../common';
+import { buildAuthCookieOptions, Public } from '../../common';
 import { AuthService } from './auth.service';
 import { LocalAuthGuard } from './guards/local-auth.guard';
 import { LoginDto } from './dto/login.dto';
@@ -14,6 +14,7 @@ export class AuthController {
     private readonly configService: ConfigService,
   ) {}
 
+  @Public()
   @UseGuards(LocalAuthGuard)
   @Post('login')
   async login(
@@ -32,6 +33,7 @@ export class AuthController {
     return { success: true };
   }
 
+  @Public()
   @Post('refresh')
   async refresh(@Req() request: Request, @Res({ passthrough: true }) response: Response) {
     const refreshToken = request.cookies?.refresh_token;

--- a/apps/api/src/modules/auth/guards/jwt-auth.guard.ts
+++ b/apps/api/src/modules/auth/guards/jwt-auth.guard.ts
@@ -1,5 +1,25 @@
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import { Reflector } from '@nestjs/core';
+
+import { IS_PUBLIC_KEY } from '../../../common';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private readonly reflector: Reflector) {
+    super();
+  }
+
+  canActivate(context: ExecutionContext) {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (isPublic) {
+      return true;
+    }
+
+    return super.canActivate(context);
+  }
+}


### PR DESCRIPTION
## Summary
- add global JwtAuthGuard with @Public decorator for auth exceptions
- add RolesGuard and @Roles decorator for role-based access
- register guards globally in AppModule

## Testing
- APP_PORT=3001 DATABASE_URL=postgresql://postgres:postgres@postgres:5432/let_me_out?schema=public JWT_SECRET=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa JWT_REFRESH_SECRET=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb JWT_EXPIRES_IN=15m JWT_REFRESH_EXPIRES_IN=7d SMTP_HOST=smtp.example.com SMTP_PORT=587 SMTP_SECURE=false SMTP_USER=user SMTP_PASS=pass SMTP_FROM=no-reply@example.com CORS_ORIGIN=http://localhost:5173 COOKIE_SAMESITE=none COOKIE_SECURE=true pnpm --filter @repo/api dev
- curl -i http://localhost:3001/me (expect 401 without cookie)
- curl -i -X POST http://localhost:3001/auth/refresh (expect 401 without cookie)
- pnpm --filter @repo/api typecheck
- pnpm lint

Closes #39