### PR TITLE
[Frontend] TanStack Query setup

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.90.21",
+    "@tanstack/react-query-devtools": "^5.91.3",
     "@tanstack/react-router": "^1.163.3",
     "@tanstack/router-devtools": "^1.163.3",
     "axios": "^1.13.6",

--- a/apps/web/src/lib/query-client.test.tsx
+++ b/apps/web/src/lib/query-client.test.tsx
@@ -1,0 +1,130 @@
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import { AxiosError, AxiosHeaders } from 'axios';
+import { describe, expect, it } from 'vitest';
+
+import { queryClient } from '../lib/query-client';
+import { shouldRetry } from '../lib/query-retry';
+
+function makeAxiosError(status: number): AxiosError {
+  const headers = new AxiosHeaders();
+  return new AxiosError(
+    `Request failed with status code ${status}`,
+    String(status),
+    { headers, url: '/test', method: 'get' },
+    null,
+    { status, statusText: '', data: null, headers, config: { headers } }
+  );
+}
+
+function makeTestClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000,
+        retry: shouldRetry,
+        refetchOnWindowFocus: true,
+        gcTime: 0,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+}
+
+describe('queryClient defaults', () => {
+  it('tiene staleTime de 60 segundos por defecto', () => {
+    const defaults = queryClient.getDefaultOptions();
+    expect(defaults.queries?.staleTime).toBe(60 * 1000);
+  });
+
+  it('no reintenta mutations por defecto', () => {
+    const defaults = queryClient.getDefaultOptions();
+    expect(defaults.mutations?.retry).toBe(false);
+  });
+
+  it('tiene refetchOnWindowFocus activado', () => {
+    const defaults = queryClient.getDefaultOptions();
+    expect(defaults.queries?.refetchOnWindowFocus).toBe(true);
+  });
+});
+
+describe('shouldRetry: logica de reintentos', () => {
+  it('no reintenta en errores 401', () => {
+    expect(shouldRetry(0, makeAxiosError(401))).toBe(false);
+  });
+
+  it('no reintenta en errores 403', () => {
+    expect(shouldRetry(0, makeAxiosError(403))).toBe(false);
+  });
+
+  it('no reintenta en errores 404', () => {
+    expect(shouldRetry(0, makeAxiosError(404))).toBe(false);
+  });
+
+  it('reintenta en el primer fallo con errores 500', () => {
+    expect(shouldRetry(0, makeAxiosError(500))).toBe(true);
+  });
+
+  it('no reintenta en el segundo fallo con errores 500', () => {
+    expect(shouldRetry(1, makeAxiosError(500))).toBe(false);
+  });
+
+  it('reintenta en el primer fallo con errores de red (sin response)', () => {
+    const networkError = new Error('Network Error');
+    expect(shouldRetry(0, networkError)).toBe(true);
+  });
+});
+
+describe('QueryClient: comportamiento de retry en queries reales', () => {
+  it('no reintenta en errores 401', async () => {
+    const client = makeTestClient();
+    let callCount = 0;
+
+    function TestComponent() {
+      useQuery({
+        queryKey: ['test-401'],
+        queryFn: () => {
+          callCount++;
+          return Promise.reject(makeAxiosError(401));
+        },
+      });
+      return null;
+    }
+
+    render(
+      <QueryClientProvider client={client}>
+        <TestComponent />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => expect(callCount).toBe(1), { timeout: 3000 });
+    expect(callCount).toBe(1);
+  });
+
+  it('reintenta una vez en errores 500', async () => {
+    const client = makeTestClient();
+    let callCount = 0;
+
+    function TestComponent() {
+      useQuery({
+        queryKey: ['test-500'],
+        queryFn: () => {
+          callCount++;
+          return Promise.reject(makeAxiosError(500));
+        },
+      });
+      return null;
+    }
+
+    render(
+      <QueryClientProvider client={client}>
+        <TestComponent />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => expect(callCount).toBe(2), { timeout: 5000 });
+    expect(callCount).toBe(2);
+  });
+});

--- a/apps/web/src/lib/query-client.ts
+++ b/apps/web/src/lib/query-client.ts
@@ -1,0 +1,16 @@
+import { QueryClient } from '@tanstack/react-query';
+
+import { shouldRetry } from './query-retry';
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60 * 1000,
+      retry: shouldRetry,
+      refetchOnWindowFocus: true,
+    },
+    mutations: {
+      retry: false,
+    },
+  },
+});

--- a/apps/web/src/lib/query-retry.ts
+++ b/apps/web/src/lib/query-retry.ts
@@ -1,0 +1,14 @@
+import { isAxiosError } from 'axios';
+
+const SHOULD_NOT_RETRY_STATUSES = new Set([401, 403, 404]);
+
+export function shouldRetry(failureCount: number, error: unknown): boolean {
+  if (
+    isAxiosError(error) &&
+    error.response &&
+    SHOULD_NOT_RETRY_STATUSES.has(error.response.status)
+  ) {
+    return false;
+  }
+  return failureCount < 1;
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,7 +1,9 @@
+import { QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider } from '@tanstack/react-router';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 
+import { queryClient } from './lib/query-client';
 import { router } from './router';
 import './styles.css';
 
@@ -14,6 +16,8 @@ if (!container) {
 const root = createRoot(container);
 root.render(
   <StrictMode>
-    <RouterProvider router={router} />
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
   </StrictMode>
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,12 @@ importers:
 
   apps/web:
     dependencies:
+      '@tanstack/react-query':
+        specifier: ^5.90.21
+        version: 5.90.21(react@18.3.1)
+      '@tanstack/react-query-devtools':
+        specifier: ^5.91.3
+        version: 5.91.3(@tanstack/react-query@5.90.21(react@18.3.1))(react@18.3.1)
       '@tanstack/react-router':
         specifier: ^1.163.3
         version: 1.163.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1196,6 +1202,23 @@ packages:
   '@tanstack/history@1.161.4':
     resolution: {integrity: sha512-Kp/WSt411ZWYvgXy6uiv5RmhHrz9cAml05AQPrtdAp7eUqvIDbMGPnML25OKbzR3RJ1q4wgENxDTvlGPa9+Mww==}
     engines: {node: '>=20.19'}
+
+  '@tanstack/query-core@5.90.20':
+    resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
+
+  '@tanstack/query-devtools@5.93.0':
+    resolution: {integrity: sha512-+kpsx1NQnOFTZsw6HAFCW3HkKg0+2cepGtAWXjiiSOJJ1CtQpt72EE2nyZb+AjAbLRPoeRmPJ8MtQd8r8gsPdg==}
+
+  '@tanstack/react-query-devtools@5.91.3':
+    resolution: {integrity: sha512-nlahjMtd/J1h7IzOOfqeyDh5LNfG0eULwlltPEonYy0QL+nqrBB+nyzJfULV+moL7sZyxc2sHdNJki+vLA9BSA==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.90.20
+      react: ^18 || ^19
+
+  '@tanstack/react-query@5.90.21':
+    resolution: {integrity: sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@tanstack/react-router-devtools@1.163.3':
     resolution: {integrity: sha512-42VMkV/2Z8ro7xzblPBRNZIEmCNXMzm2jD68G52p2qhjXm38wGpg46qneAESN9FtTQeVWk5aSXs47/jt7lkzmw==}
@@ -6086,6 +6109,21 @@ snapshots:
       '@sinonjs/commons': 3.0.1
 
   '@tanstack/history@1.161.4': {}
+
+  '@tanstack/query-core@5.90.20': {}
+
+  '@tanstack/query-devtools@5.93.0': {}
+
+  '@tanstack/react-query-devtools@5.91.3(@tanstack/react-query@5.90.21(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-devtools': 5.93.0
+      '@tanstack/react-query': 5.90.21(react@18.3.1)
+      react: 18.3.1
+
+  '@tanstack/react-query@5.90.21(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.90.20
+      react: 18.3.1
 
   '@tanstack/react-router-devtools@1.163.3(@tanstack/react-router@1.163.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@tanstack/router-core@1.163.3)(csstype@3.2.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
## Summary

- Installs `@tanstack/react-query` and `@tanstack/react-query-devtools` in `@repo/web`.
- Creates `src/lib/query-retry.ts` with `shouldRetry` function: no retry on 401/403/404, one retry on other errors (e.g. 500, network errors).
- Creates `src/lib/query-client.ts` with a `QueryClient` configured with `staleTime: 60s`, `retry: shouldRetry`, `refetchOnWindowFocus: true` and `mutations.retry: false`.
- Wraps `RouterProvider` with `QueryClientProvider` in `main.tsx`.
- Adds 11 unit tests covering defaults and retry behaviour (15 total across the web app, all passing).
- Lint and typecheck pass with zero errors.

## Acceptance criteria

- [x] QueryClientProvider configurado
- [x] Configuracion base para retries y staleTime
- [x] La funcionalidad ha sido probada manualmente en el entorno de desarrollo

Closes #43
