### PR TITLE
feat(web): Adds login screen with RHF + Zod validation and redirect

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.2.2",
+    "@repo/types": "workspace:^",
     "@tanstack/react-query": "^5.90.21",
     "@tanstack/react-query-devtools": "^5.91.3",
     "@tanstack/react-router": "^1.163.3",
@@ -18,6 +20,8 @@
     "axios": "^1.13.6",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-hook-form": "^7.71.2",
+    "zod": "^3.25.76",
     "zustand": "^5.0.11"
   },
   "devDependencies": {

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -11,3 +11,12 @@ export async function fetchMe(): Promise<SessionUser> {
   const response = await apiClient.get<SessionUser>('/auth/me');
   return response.data;
 }
+
+export interface LoginCredentials {
+  email: string;
+  password: string;
+}
+
+export async function login(credentials: LoginCredentials): Promise<void> {
+  await apiClient.post<{ success: boolean }>('/auth/login', credentials);
+}

--- a/apps/web/src/pages/login/LoginPage.test.tsx
+++ b/apps/web/src/pages/login/LoginPage.test.tsx
@@ -1,0 +1,165 @@
+import { createMemoryHistory, createRouter, RouterProvider } from '@tanstack/react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { authRoute } from '../../routes/_auth';
+import { dashboardRoute } from '../../routes/_auth.index';
+import { publicRoute } from '../../routes/_public';
+import { loginRoute } from '../../routes/_public.login';
+import { rootRoute } from '../../routes/__root';
+import { useAuthStore } from '../../store/auth.store';
+
+const mockUser = {
+  id: '01234567-89ab-7def-0123-456789abcdef',
+  name: 'Ana Garcia',
+  email: 'ana@example.com',
+  role: 'EMPLOYEE' as const,
+  isActive: true,
+};
+
+const server = setupServer(http.get('*/auth/me', () => new HttpResponse(null, { status: 401 })));
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers();
+  useAuthStore.setState({ user: null, isLoading: false });
+});
+afterAll(() => server.close());
+
+function buildRouter() {
+  const routeTree = rootRoute.addChildren([
+    publicRoute.addChildren([loginRoute]),
+    authRoute.addChildren([dashboardRoute]),
+  ]);
+
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: ['/login'] }),
+  });
+}
+
+function renderLogin() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const router = buildRouter();
+  render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  );
+  return { router };
+}
+
+describe('LoginPage', () => {
+  it('renders the login form with email and password fields', async () => {
+    renderLogin();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Iniciar sesión' })).toBeInTheDocument();
+    });
+
+    expect(screen.getByLabelText('Correo electrónico')).toBeInTheDocument();
+    expect(screen.getByLabelText('Contraseña')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Entrar' })).toBeInTheDocument();
+  });
+
+  it('shows validation errors when submitting empty form', async () => {
+    const user = userEvent.setup();
+    renderLogin();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Entrar' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Entrar' }));
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('alert').length).toBeGreaterThan(0);
+    });
+  });
+
+  it('shows validation error for invalid email format', async () => {
+    const user = userEvent.setup();
+    renderLogin();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Correo electrónico')).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByLabelText('Correo electrónico'), 'not-an-email');
+    await user.type(screen.getByLabelText('Contraseña'), 'secret');
+    await user.click(screen.getByRole('button', { name: 'Entrar' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+
+  it('shows API error message on 401 response', async () => {
+    server.use(http.post('*/auth/login', () => new HttpResponse(null, { status: 401 })));
+
+    const user = userEvent.setup();
+    renderLogin();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Correo electrónico')).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByLabelText('Correo electrónico'), 'user@example.com');
+    await user.type(screen.getByLabelText('Contraseña'), 'wrongpassword');
+    await user.click(screen.getByRole('button', { name: 'Entrar' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Credenciales incorrectas.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows generic error message on unexpected API error', async () => {
+    server.use(http.post('*/auth/login', () => new HttpResponse(null, { status: 500 })));
+
+    const user = userEvent.setup();
+    renderLogin();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Correo electrónico')).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByLabelText('Correo electrónico'), 'user@example.com');
+    await user.type(screen.getByLabelText('Contraseña'), 'password');
+    await user.click(screen.getByRole('button', { name: 'Entrar' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Error inesperado. Inténtalo de nuevo.')).toBeInTheDocument();
+    });
+  });
+
+  it('redirects to dashboard after successful login', async () => {
+    // First /auth/me call (root beforeLoad) returns 401 → login page shown.
+    // Second call (post-login fetchMe) returns the user → dashboard rendered.
+    server.use(
+      http.post('*/auth/login', () => HttpResponse.json({ success: true })),
+      http.get('*/auth/me', () => new HttpResponse(null, { status: 401 }), { once: true }),
+      http.get('*/auth/me', () => HttpResponse.json(mockUser))
+    );
+
+    const user = userEvent.setup();
+    renderLogin();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Correo electrónico')).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByLabelText('Correo electrónico'), 'ana@example.com');
+    await user.type(screen.getByLabelText('Contraseña'), 'correctpassword');
+    await user.click(screen.getByRole('button', { name: 'Entrar' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/pages/login/LoginPage.tsx
+++ b/apps/web/src/pages/login/LoginPage.tsx
@@ -1,8 +1,91 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from '@tanstack/react-router';
+import { isAxiosError } from 'axios';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { LoginSchema } from '@repo/types';
+
+import { login, fetchMe } from '../../lib/api-client';
+import { useAuthStore } from '../../store/auth.store';
+
+type LoginFormValues = z.infer<typeof LoginSchema>;
+
 export function LoginPage() {
+  const router = useRouter();
+  const setUser = useAuthStore((s) => s.setUser);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    setError,
+  } = useForm<LoginFormValues>({
+    resolver: zodResolver(LoginSchema),
+  });
+
+  const onSubmit = async (data: LoginFormValues) => {
+    try {
+      await login(data);
+      const user = await fetchMe();
+      setUser(user);
+      await router.navigate({ to: '/' });
+    } catch (error) {
+      const message =
+        isAxiosError(error) && error.response?.status === 401
+          ? 'Credenciales incorrectas.'
+          : 'Error inesperado. Inténtalo de nuevo.';
+      setError('root', { message });
+    }
+  };
+
   return (
-    <div>
-      <h1>Iniciar sesion</h1>
-      <p>Formulario de login pendiente de implementar.</p>
-    </div>
+    <main>
+      <h1>Iniciar sesión</h1>
+      <form onSubmit={handleSubmit(onSubmit)} noValidate>
+        <div>
+          <label htmlFor="email">Correo electrónico</label>
+          <input
+            id="email"
+            type="email"
+            autoComplete="email"
+            aria-invalid={errors.email ? 'true' : undefined}
+            aria-describedby={errors.email ? 'email-error' : undefined}
+            {...register('email')}
+          />
+          {errors.email && (
+            <span id="email-error" role="alert">
+              {errors.email.message}
+            </span>
+          )}
+        </div>
+
+        <div>
+          <label htmlFor="password">Contraseña</label>
+          <input
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            aria-invalid={errors.password ? 'true' : undefined}
+            aria-describedby={errors.password ? 'password-error' : undefined}
+            {...register('password')}
+          />
+          {errors.password && (
+            <span id="password-error" role="alert">
+              {errors.password.message}
+            </span>
+          )}
+        </div>
+
+        {errors.root && (
+          <div role="alert" aria-live="assertive">
+            {errors.root.message}
+          </div>
+        )}
+
+        <button type="submit" disabled={isSubmitting}>
+          {isSubmitting ? 'Entrando…' : 'Entrar'}
+        </button>
+      </form>
+    </main>
   );
 }

--- a/apps/web/src/routes/routes.test.tsx
+++ b/apps/web/src/routes/routes.test.tsx
@@ -51,7 +51,7 @@ describe('Guard de navegacion: ruta autenticada', () => {
     render(<RouterProvider router={router} />);
 
     await waitFor(() => {
-      expect(screen.queryByText('Iniciar sesion')).toBeInTheDocument();
+      expect(screen.queryByText('Iniciar sesión')).toBeInTheDocument();
     });
   });
 
@@ -83,7 +83,7 @@ describe('Guard de navegacion: ruta publica', () => {
     render(<RouterProvider router={router} />);
 
     await waitFor(() => {
-      expect(screen.getByText('Iniciar sesion')).toBeInTheDocument();
+      expect(screen.getByText('Iniciar sesión')).toBeInTheDocument();
     });
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,12 @@ importers:
 
   apps/web:
     dependencies:
+      '@hookform/resolvers':
+        specifier: ^5.2.2
+        version: 5.2.2(react-hook-form@7.71.2(react@18.3.1))
+      '@repo/types':
+        specifier: workspace:^
+        version: link:../../packages/types
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@18.3.1)
@@ -168,6 +174,12 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-hook-form:
+        specifier: ^7.71.2
+        version: 7.71.2(react@18.3.1)
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
       zustand:
         specifier: ^5.0.11
         version: 5.0.11(@types/react@18.3.28)(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
@@ -756,6 +768,11 @@ packages:
   '@hapi/topo@5.1.0':
     resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
 
+  '@hookform/resolvers@5.2.2':
+    resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
+    peerDependencies:
+      react-hook-form: ^7.55.0
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1198,6 +1215,9 @@ packages:
 
   '@sinonjs/fake-timers@10.3.0':
     resolution: {integrity: sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@tanstack/history@1.161.4':
     resolution: {integrity: sha512-Kp/WSt411ZWYvgXy6uiv5RmhHrz9cAml05AQPrtdAp7eUqvIDbMGPnML25OKbzR3RJ1q4wgENxDTvlGPa9+Mww==}
@@ -4042,6 +4062,12 @@ packages:
     peerDependencies:
       react: ^18.3.1
 
+  react-hook-form@7.71.2:
+    resolution: {integrity: sha512-1CHvcDYzuRUNOflt4MOq3ZM46AronNJtQ1S7tnX6YN4y72qhgiUItpacZUAQ0TyWYci3yz1X+rXaSxiuEm86PA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -5584,6 +5610,11 @@ snapshots:
     dependencies:
       '@hapi/hoek': 9.3.0
 
+  '@hookform/resolvers@5.2.2(react-hook-form@7.71.2(react@18.3.1))':
+    dependencies:
+      '@standard-schema/utils': 0.3.0
+      react-hook-form: 7.71.2(react@18.3.1)
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -6107,6 +6138,8 @@ snapshots:
   '@sinonjs/fake-timers@10.3.0':
     dependencies:
       '@sinonjs/commons': 3.0.1
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@tanstack/history@1.161.4': {}
 
@@ -9530,6 +9563,10 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-hook-form@7.71.2(react@18.3.1):
+    dependencies:
+      react: 18.3.1
 
   react-is@16.13.1: {}
 


### PR DESCRIPTION
## Summary

Closes #46

Implements the login screen with full form validation and API integration:

- React Hook Form + zodResolver with LoginSchema from @repo/types
- Inline field-level validation errors (email format, required fields)
- On 401 from API: shows "Credenciales incorrectas."
- On other errors: shows "Error inesperado. Intentalo de nuevo."
- On success: calls /auth/login, fetches /auth/me, updates Zustand store, navigates to /
- Button disabled and shows "Entrando..." while submitting
- Accessible: labels, aria-invalid, aria-describedby, role=alert

## Dependencies added

- @repo/types (workspace package, for LoginSchema)
- react-hook-form
- @hookform/resolvers
- zod (already in @repo/types, now also in web for type inference)

## Tests

6 tests in LoginPage.test.tsx:
- Renders form with email, password fields and submit button
- Shows validation errors on empty submit
- Shows validation error for invalid email format
- Shows API error on 401
- Shows generic error on 500
- Redirects to dashboard after successful login

All 30 web tests pass.
