### PR TITLE
feat(web): Adds useSession hook backed by TanStack Query and GET /auth/me

### DIFF
--- a/apps/web/src/hooks/use-session.test.tsx
+++ b/apps/web/src/hooks/use-session.test.tsx
@@ -1,0 +1,91 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import type { ReactNode } from 'react';
+
+import { useSession } from './use-session';
+import { useAuthStore } from '../store/auth.store';
+
+const mockUser = {
+  id: '01234567-89ab-7def-0123-456789abcdef',
+  name: 'Ana Garcia',
+  email: 'ana@example.com',
+  role: 'EMPLOYEE' as const,
+  isActive: true,
+};
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers();
+  useAuthStore.setState({ user: null, isLoading: false });
+});
+afterAll(() => server.close());
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  }
+  return Wrapper;
+}
+
+describe('useSession', () => {
+  it('returns isLoading=true initially', () => {
+    server.use(
+      http.get('*/auth/me', async () => {
+        await new Promise((r) => setTimeout(r, 200));
+        return HttpResponse.json(mockUser);
+      })
+    );
+
+    const { result } = renderHook(() => useSession(), { wrapper: createWrapper() });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.user).toBeNull();
+  });
+
+  it('returns the user and updates Zustand store on success', async () => {
+    server.use(http.get('*/auth/me', () => HttpResponse.json(mockUser)));
+
+    const { result } = renderHook(() => useSession(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.user).toEqual(mockUser);
+    expect(result.current.isError).toBe(false);
+    expect(useAuthStore.getState().user).toEqual(mockUser);
+  });
+
+  it('returns isError=true and null user on API failure', async () => {
+    server.use(http.get('*/auth/me', () => new HttpResponse(null, { status: 401 })));
+
+    const { result } = renderHook(() => useSession(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isError).toBe(true);
+    expect(result.current.user).toBeNull();
+  });
+
+  it('does not update Zustand store on API failure', async () => {
+    server.use(http.get('*/auth/me', () => new HttpResponse(null, { status: 500 })));
+
+    const { result } = renderHook(() => useSession(), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(useAuthStore.getState().user).toBeNull();
+  });
+});

--- a/apps/web/src/hooks/use-session.ts
+++ b/apps/web/src/hooks/use-session.ts
@@ -1,0 +1,27 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchMe } from '../lib/api-client';
+import { sessionKeys } from '../lib/query-keys/session.keys';
+import { useAuthStore } from '../store/auth.store';
+import type { SessionUser } from '../store/auth.store';
+
+export function useSession() {
+  const setUser = useAuthStore((s) => s.setUser);
+
+  const {
+    data: user,
+    isLoading,
+    isError,
+  } = useQuery<SessionUser>({
+    queryKey: sessionKeys.me(),
+    queryFn: async () => {
+      const me = await fetchMe();
+      setUser(me);
+      return me;
+    },
+    retry: false,
+    staleTime: 60 * 1000,
+  });
+
+  return { user: user ?? null, isLoading, isError };
+}

--- a/apps/web/src/lib/query-keys/session.keys.ts
+++ b/apps/web/src/lib/query-keys/session.keys.ts
@@ -1,0 +1,4 @@
+export const sessionKeys = {
+  all: ['session'] as const,
+  me: () => [...sessionKeys.all, 'me'] as const,
+};


### PR DESCRIPTION
## Summary

Closes #47

Adds useSession hook that:

- Calls GET /auth/me via the existing Axios client (withCredentials)
- Uses TanStack Query with sessionKeys query-key factory (staleTime: 60s, retry: false)
- Syncs the result into the Zustand auth store on success
- Exposes { user, isLoading, isError } for consumers to handle all states

Note: the issue referenced GET /me but the correct endpoint is GET /auth/me
following the fix in #154 / PR #155.

## Files

- src/hooks/use-session.ts - the hook
- src/lib/query-keys/session.keys.ts - centralised query key factory
- src/hooks/use-session.test.tsx - 4 unit tests

## Tests

4 tests covering: initial loading state, successful fetch + Zustand update,
API error state, and no store update on failure. All 40 web tests pass.
