### PR TITLE
fix(api): Corrects .env path resolution from three levels to two

### DIFF
--- a/apps/api/src/modules/app.module.ts
+++ b/apps/api/src/modules/app.module.ts
@@ -13,7 +13,7 @@ import { AuthModule } from './auth';
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      envFilePath: path.resolve(process.cwd(), '../../..', '.env'),
+      envFilePath: path.resolve(process.cwd(), '../..', '.env'),
       validationSchema: envValidationSchema,
     }),
     AuthModule,


### PR DESCRIPTION
## Summary

Fixes #159

The .env file was never loaded because the path resolution was wrong.

With process.cwd() = /workspace/apps/api (devcontainer working directory):

  Before: path.resolve(cwd, '../../..', '.env') → /.env  (filesystem root, does not exist)
  After:  path.resolve(cwd, '../..', '.env')  → /workspace/.env  ✓

The extra level of traversal meant all environment variables were undefined at startup. Since most are read with getOrThrow(), the app crashed immediately without loading any config.

## Tests

All 3 backend tests pass. Lint and typecheck clean.
