### PR TITLE
feat(web): Adds role-based route guards with requireRole helper

### DIFF
--- a/apps/web/src/lib/require-role.test.ts
+++ b/apps/web/src/lib/require-role.test.ts
@@ -1,0 +1,86 @@
+import { redirect } from '@tanstack/react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useAuthStore } from '../store/auth.store';
+import { requireRole } from './require-role';
+
+vi.mock('@tanstack/react-router', () => ({
+  redirect: vi.fn((args: { to: string }) => {
+    throw new Error(`redirect:${args.to}`);
+  }),
+}));
+
+afterEach(() => {
+  useAuthStore.setState({ user: null, isLoading: false });
+  vi.clearAllMocks();
+});
+
+describe('requireRole', () => {
+  it('no lanza cuando el usuario tiene el rol permitido', () => {
+    useAuthStore.setState({
+      user: {
+        id: '1',
+        name: 'Admin',
+        email: 'admin@example.com',
+        role: 'ADMIN',
+        isActive: true,
+      },
+      isLoading: false,
+    });
+
+    expect(() => requireRole(['ADMIN'])).not.toThrow();
+  });
+
+  it('redirige a /unauthorized cuando el usuario no tiene el rol requerido', () => {
+    useAuthStore.setState({
+      user: {
+        id: '2',
+        name: 'Ana',
+        email: 'ana@example.com',
+        role: 'EMPLOYEE',
+        isActive: true,
+      },
+      isLoading: false,
+    });
+
+    expect(() => requireRole(['ADMIN'])).toThrow('redirect:/unauthorized');
+    expect(redirect).toHaveBeenCalledWith({ to: '/unauthorized' });
+  });
+
+  it('redirige a /unauthorized cuando no hay sesion activa', () => {
+    useAuthStore.setState({ user: null, isLoading: false });
+
+    expect(() => requireRole(['ADMIN'])).toThrow('redirect:/unauthorized');
+    expect(redirect).toHaveBeenCalledWith({ to: '/unauthorized' });
+  });
+
+  it('no lanza cuando el rol del usuario es uno de los varios permitidos', () => {
+    useAuthStore.setState({
+      user: {
+        id: '3',
+        name: 'Val',
+        email: 'val@example.com',
+        role: 'VALIDATOR',
+        isActive: true,
+      },
+      isLoading: false,
+    });
+
+    expect(() => requireRole(['ADMIN', 'VALIDATOR'])).not.toThrow();
+  });
+
+  it('redirige cuando el rol del usuario no esta en la lista de varios roles permitidos', () => {
+    useAuthStore.setState({
+      user: {
+        id: '4',
+        name: 'Emp',
+        email: 'emp@example.com',
+        role: 'EMPLOYEE',
+        isActive: true,
+      },
+      isLoading: false,
+    });
+
+    expect(() => requireRole(['ADMIN', 'VALIDATOR'])).toThrow('redirect:/unauthorized');
+  });
+});

--- a/apps/web/src/lib/require-role.ts
+++ b/apps/web/src/lib/require-role.ts
@@ -1,0 +1,18 @@
+import { redirect } from '@tanstack/react-router';
+
+import type { UserRole } from '../store/auth.store';
+import { useAuthStore } from '../store/auth.store';
+
+/**
+ * Throws a redirect to /unauthorized if the current user's role
+ * is not included in the allowed roles list.
+ *
+ * Intended to be called inside a route's beforeLoad callback.
+ */
+export function requireRole(allowedRoles: UserRole[]): void {
+  const { user } = useAuthStore.getState();
+
+  if (!user || !allowedRoles.includes(user.role)) {
+    throw redirect({ to: '/unauthorized' });
+  }
+}

--- a/apps/web/src/pages/admin/AdminPage.tsx
+++ b/apps/web/src/pages/admin/AdminPage.tsx
@@ -1,0 +1,7 @@
+export function AdminPage() {
+  return (
+    <div>
+      <h1>Administración</h1>
+    </div>
+  );
+}

--- a/apps/web/src/pages/unauthorized/UnauthorizedPage.tsx
+++ b/apps/web/src/pages/unauthorized/UnauthorizedPage.tsx
@@ -1,0 +1,11 @@
+import { Link } from '@tanstack/react-router';
+
+export function UnauthorizedPage() {
+  return (
+    <main className="unauthorized-page">
+      <h1>Acceso no permitido</h1>
+      <p>No tienes permisos para acceder a esta página.</p>
+      <Link to="/">Volver al inicio</Link>
+    </main>
+  );
+}

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -1,14 +1,18 @@
 import { createRouter } from '@tanstack/react-router';
 
 import { authRoute } from './routes/_auth';
+import { adminRoute } from './routes/_auth.admin';
+import { adminIndexRoute } from './routes/_auth.admin.index';
 import { dashboardRoute } from './routes/_auth.index';
 import { publicRoute } from './routes/_public';
 import { loginRoute } from './routes/_public.login';
 import { rootRoute } from './routes/__root';
+import { unauthorizedRoute } from './routes/unauthorized';
 
 const routeTree = rootRoute.addChildren([
   publicRoute.addChildren([loginRoute]),
-  authRoute.addChildren([dashboardRoute]),
+  authRoute.addChildren([dashboardRoute, adminRoute.addChildren([adminIndexRoute])]),
+  unauthorizedRoute,
 ]);
 
 export const router = createRouter({ routeTree });

--- a/apps/web/src/routes/_auth.admin.index.tsx
+++ b/apps/web/src/routes/_auth.admin.index.tsx
@@ -1,0 +1,10 @@
+import { createRoute } from '@tanstack/react-router';
+
+import { AdminPage } from '../pages/admin/AdminPage';
+import { adminRoute } from './_auth.admin';
+
+export const adminIndexRoute = createRoute({
+  getParentRoute: () => adminRoute,
+  path: '/admin',
+  component: AdminPage,
+});

--- a/apps/web/src/routes/_auth.admin.tsx
+++ b/apps/web/src/routes/_auth.admin.tsx
@@ -1,0 +1,12 @@
+import { createRoute } from '@tanstack/react-router';
+
+import { requireRole } from '../lib/require-role';
+import { authRoute } from './_auth';
+
+export const adminRoute = createRoute({
+  getParentRoute: () => authRoute,
+  id: '_admin',
+  beforeLoad: () => {
+    requireRole(['ADMIN']);
+  },
+});

--- a/apps/web/src/routes/routes.test.tsx
+++ b/apps/web/src/routes/routes.test.tsx
@@ -5,10 +5,13 @@ import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { authRoute } from '../routes/_auth';
+import { adminRoute } from '../routes/_auth.admin';
+import { adminIndexRoute } from '../routes/_auth.admin.index';
 import { dashboardRoute } from '../routes/_auth.index';
 import { publicRoute } from '../routes/_public';
 import { loginRoute } from '../routes/_public.login';
 import { rootRoute } from '../routes/__root';
+import { unauthorizedRoute } from '../routes/unauthorized';
 import { useAuthStore } from '../store/auth.store';
 
 const mockUser = {
@@ -30,7 +33,8 @@ afterAll(() => server.close());
 function buildRouter(initialPath: string) {
   const routeTree = rootRoute.addChildren([
     publicRoute.addChildren([loginRoute]),
-    authRoute.addChildren([dashboardRoute]),
+    authRoute.addChildren([dashboardRoute, adminRoute.addChildren([adminIndexRoute])]),
+    unauthorizedRoute,
   ]);
 
   return createRouter({
@@ -99,6 +103,39 @@ describe('Guard de navegacion: ruta publica', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('Guard de rol: ruta de administracion', () => {
+  it('muestra la pagina de admin cuando el usuario es ADMIN', async () => {
+    const adminUser = { ...mockUser, role: 'ADMIN' as const };
+    server.use(
+      http.get('*/auth/me', () => {
+        return HttpResponse.json(adminUser);
+      })
+    );
+
+    const router = buildRouter('/admin');
+    render(<RouterProvider router={router} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Administración')).toBeInTheDocument();
+    });
+  });
+
+  it('redirige a /unauthorized cuando el usuario no es ADMIN', async () => {
+    server.use(
+      http.get('*/auth/me', () => {
+        return HttpResponse.json(mockUser);
+      })
+    );
+
+    const router = buildRouter('/admin');
+    render(<RouterProvider router={router} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Acceso no permitido')).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/routes/unauthorized.tsx
+++ b/apps/web/src/routes/unauthorized.tsx
@@ -1,0 +1,10 @@
+import { createRoute } from '@tanstack/react-router';
+
+import { UnauthorizedPage } from '../pages/unauthorized/UnauthorizedPage';
+import { rootRoute } from './__root';
+
+export const unauthorizedRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: '/unauthorized',
+  component: UnauthorizedPage,
+});


### PR DESCRIPTION
## Summary

- Adds `requireRole(allowedRoles)` utility that reads the user role from Zustand and throws a TanStack Router redirect to `/unauthorized` when access is denied.
- Adds `_auth.admin.tsx` as the first concrete role-protected layout route (ADMIN only), serving as the pattern for future role guards.
- Adds `UnauthorizedPage` and its route `/unauthorized`.
- Registers all new routes in `router.ts` so the router type system recognises `/unauthorized` and `/admin` as valid paths.
- 5 unit tests for `requireRole` and 2 integration tests via `routes.test.tsx`.

Closes #48
