### PR TITLE
feat(admin): Adds admin user list page with TanStack Query

### DIFF
--- a/apps/web/src/components/users/UserTable.test.tsx
+++ b/apps/web/src/components/users/UserTable.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { UserRole } from '@repo/types';
+import type { User } from '@repo/types';
+
+import { UserTable } from './UserTable';
+
+const makeUser = (overrides: Partial<User> = {}): User => ({
+  id: '01930000-0000-7000-8000-000000000001',
+  name: 'Ana García',
+  email: 'ana@example.com',
+  role: UserRole.STANDARD,
+  isActive: true,
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  ...overrides,
+});
+
+describe('UserTable', () => {
+  it('renders empty state when no users are provided', () => {
+    render(<UserTable users={[]} />);
+
+    expect(screen.getByText('No hay usuarios registrados.')).toBeInTheDocument();
+  });
+
+  it('renders a row for each user', () => {
+    const users = [
+      makeUser({ id: '01930000-0000-7000-8000-000000000001', name: 'Ana García' }),
+      makeUser({
+        id: '01930000-0000-7000-8000-000000000002',
+        name: 'Luis Pérez',
+        email: 'luis@example.com',
+      }),
+    ];
+
+    render(<UserTable users={users} />);
+
+    expect(screen.getByText('Ana García')).toBeInTheDocument();
+    expect(screen.getByText('Luis Pérez')).toBeInTheDocument();
+  });
+
+  it('displays the correct role label for each UserRole', () => {
+    const users = [
+      makeUser({ id: '01930000-0000-7000-8000-000000000001', role: UserRole.STANDARD }),
+      makeUser({
+        id: '01930000-0000-7000-8000-000000000002',
+        role: UserRole.VALIDATOR,
+        email: 'v@example.com',
+      }),
+      makeUser({
+        id: '01930000-0000-7000-8000-000000000003',
+        role: UserRole.AUDITOR,
+        email: 'a@example.com',
+      }),
+      makeUser({
+        id: '01930000-0000-7000-8000-000000000004',
+        role: UserRole.ADMIN,
+        email: 'ad@example.com',
+      }),
+    ];
+
+    render(<UserTable users={users} />);
+
+    expect(screen.getByText('Empleado')).toBeInTheDocument();
+    expect(screen.getByText('Validador')).toBeInTheDocument();
+    expect(screen.getByText('Auditor')).toBeInTheDocument();
+    expect(screen.getByText('Administrador')).toBeInTheDocument();
+  });
+
+  it('shows "Activo" badge for active users', () => {
+    render(<UserTable users={[makeUser({ isActive: true })]} />);
+
+    expect(screen.getByText('Activo')).toBeInTheDocument();
+  });
+
+  it('shows "Inactivo" badge for inactive users', () => {
+    render(<UserTable users={[makeUser({ isActive: false })]} />);
+
+    expect(screen.getByText('Inactivo')).toBeInTheDocument();
+  });
+
+  it('renders user email', () => {
+    render(<UserTable users={[makeUser({ email: 'test@company.com' })]} />);
+
+    expect(screen.getByText('test@company.com')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/users/UserTable.tsx
+++ b/apps/web/src/components/users/UserTable.tsx
@@ -1,0 +1,61 @@
+import type { User } from '@repo/types';
+import { UserRole } from '@repo/types';
+
+const ROLE_LABELS: Record<UserRole, string> = {
+  [UserRole.STANDARD]: 'Empleado',
+  [UserRole.VALIDATOR]: 'Validador',
+  [UserRole.AUDITOR]: 'Auditor',
+  [UserRole.ADMIN]: 'Administrador',
+};
+
+interface UserTableProps {
+  users: User[];
+}
+
+export function UserTable({ users }: UserTableProps) {
+  if (users.length === 0) {
+    return (
+      <p className="py-8 text-center text-sm text-muted-foreground">No hay usuarios registrados.</p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border border-border">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border bg-muted text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            <th className="px-4 py-3">Nombre</th>
+            <th className="px-4 py-3">Correo</th>
+            <th className="px-4 py-3">Rol</th>
+            <th className="px-4 py-3">Estado</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((user, index) => (
+            <tr
+              key={user.id}
+              className={
+                index % 2 === 0 ? 'bg-card text-foreground' : 'bg-muted/40 text-foreground'
+              }
+            >
+              <td className="px-4 py-3 font-medium">{user.name}</td>
+              <td className="px-4 py-3 text-muted-foreground">{user.email}</td>
+              <td className="px-4 py-3">{ROLE_LABELS[user.role]}</td>
+              <td className="px-4 py-3">
+                <span
+                  className={
+                    user.isActive
+                      ? 'rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800'
+                      : 'rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800'
+                  }
+                >
+                  {user.isActive ? 'Activo' : 'Inactivo'}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-users.ts
+++ b/apps/web/src/hooks/use-users.ts
@@ -1,0 +1,15 @@
+import { useQuery } from '@tanstack/react-query';
+import type { User } from '@repo/types';
+
+import { listUsers } from '../lib/api-client';
+import { usersKeys } from '../lib/query-keys/users.keys';
+
+export function useUsers() {
+  const { data, isLoading, isError, error } = useQuery<User[]>({
+    queryKey: usersKeys.list(),
+    queryFn: listUsers,
+    staleTime: 30 * 1000,
+  });
+
+  return { users: data ?? [], isLoading, isError, error };
+}

--- a/apps/web/src/lib/api-client.test.ts
+++ b/apps/web/src/lib/api-client.test.ts
@@ -2,7 +2,7 @@ import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useAuthStore } from '../store/auth.store';
+import { UserRole, useAuthStore } from '../store/auth.store';
 import { apiClient } from './api-client';
 
 const server = setupServer();
@@ -44,7 +44,7 @@ describe('apiClient: interceptor de 401', () => {
 
     const replaceSpy = vi.spyOn(globalThis.location, 'replace');
     useAuthStore.setState({
-      user: { id: '1', name: 'Ana', email: 'a@b.com', role: 'EMPLOYEE', isActive: true },
+      user: { id: '1', name: 'Ana', email: 'a@b.com', role: UserRole.STANDARD, isActive: true },
       isLoading: false,
     });
 

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,4 +1,5 @@
 import axios, { isAxiosError } from 'axios';
+import type { User } from '@repo/types';
 
 import { useAuthStore } from '../store/auth.store';
 import type { SessionUser } from '../store/auth.store';
@@ -36,4 +37,9 @@ export interface LoginCredentials {
 
 export async function login(credentials: LoginCredentials): Promise<void> {
   await apiClient.post<{ success: boolean }>('/auth/login', credentials);
+}
+
+export async function listUsers(): Promise<User[]> {
+  const response = await apiClient.get<User[]>('/users');
+  return response.data;
 }

--- a/apps/web/src/lib/query-keys/users.keys.ts
+++ b/apps/web/src/lib/query-keys/users.keys.ts
@@ -1,0 +1,5 @@
+export const usersKeys = {
+  all: ['users'] as const,
+  list: () => [...usersKeys.all, 'list'] as const,
+  detail: (id: string) => [...usersKeys.all, 'detail', id] as const,
+};

--- a/apps/web/src/lib/require-role.test.ts
+++ b/apps/web/src/lib/require-role.test.ts
@@ -1,7 +1,7 @@
 import { redirect } from '@tanstack/react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { useAuthStore } from '../store/auth.store';
+import { UserRole, useAuthStore } from '../store/auth.store';
 import { requireRole } from './require-role';
 
 vi.mock('@tanstack/react-router', () => ({
@@ -22,13 +22,13 @@ describe('requireRole', () => {
         id: '1',
         name: 'Admin',
         email: 'admin@example.com',
-        role: 'ADMIN',
+        role: UserRole.ADMIN,
         isActive: true,
       },
       isLoading: false,
     });
 
-    expect(() => requireRole(['ADMIN'])).not.toThrow();
+    expect(() => requireRole([UserRole.ADMIN])).not.toThrow();
   });
 
   it('redirige a /unauthorized cuando el usuario no tiene el rol requerido', () => {
@@ -37,20 +37,20 @@ describe('requireRole', () => {
         id: '2',
         name: 'Ana',
         email: 'ana@example.com',
-        role: 'EMPLOYEE',
+        role: UserRole.STANDARD,
         isActive: true,
       },
       isLoading: false,
     });
 
-    expect(() => requireRole(['ADMIN'])).toThrow('redirect:/unauthorized');
+    expect(() => requireRole([UserRole.ADMIN])).toThrow('redirect:/unauthorized');
     expect(redirect).toHaveBeenCalledWith({ to: '/unauthorized' });
   });
 
   it('redirige a /unauthorized cuando no hay sesion activa', () => {
     useAuthStore.setState({ user: null, isLoading: false });
 
-    expect(() => requireRole(['ADMIN'])).toThrow('redirect:/unauthorized');
+    expect(() => requireRole([UserRole.ADMIN])).toThrow('redirect:/unauthorized');
     expect(redirect).toHaveBeenCalledWith({ to: '/unauthorized' });
   });
 
@@ -60,13 +60,13 @@ describe('requireRole', () => {
         id: '3',
         name: 'Val',
         email: 'val@example.com',
-        role: 'VALIDATOR',
+        role: UserRole.VALIDATOR,
         isActive: true,
       },
       isLoading: false,
     });
 
-    expect(() => requireRole(['ADMIN', 'VALIDATOR'])).not.toThrow();
+    expect(() => requireRole([UserRole.ADMIN, UserRole.VALIDATOR])).not.toThrow();
   });
 
   it('redirige cuando el rol del usuario no esta en la lista de varios roles permitidos', () => {
@@ -75,12 +75,14 @@ describe('requireRole', () => {
         id: '4',
         name: 'Emp',
         email: 'emp@example.com',
-        role: 'EMPLOYEE',
+        role: UserRole.STANDARD,
         isActive: true,
       },
       isLoading: false,
     });
 
-    expect(() => requireRole(['ADMIN', 'VALIDATOR'])).toThrow('redirect:/unauthorized');
+    expect(() => requireRole([UserRole.ADMIN, UserRole.VALIDATOR])).toThrow(
+      'redirect:/unauthorized'
+    );
   });
 });

--- a/apps/web/src/pages/admin/AdminPage.tsx
+++ b/apps/web/src/pages/admin/AdminPage.tsx
@@ -1,7 +1,34 @@
+import { UserTable } from '@/components/users/UserTable';
+import { useUsers } from '@/hooks/use-users';
+
 export function AdminPage() {
+  const { users, isLoading, isError } = useUsers();
+
   return (
-    <div>
-      <h1>Administración</h1>
+    <div className="mx-auto max-w-5xl space-y-6 p-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Usuarios</h1>
+          <p className="text-sm text-muted-foreground">Gestión de usuarios del sistema.</p>
+        </div>
+      </div>
+
+      {isLoading && (
+        <p role="status" className="py-8 text-center text-sm text-muted-foreground">
+          Cargando usuarios…
+        </p>
+      )}
+
+      {isError && !isLoading && (
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+        >
+          No se pudo cargar la lista de usuarios. Inténtalo de nuevo.
+        </div>
+      )}
+
+      {!isLoading && !isError && <UserTable users={users} />}
     </div>
   );
 }

--- a/apps/web/src/routes/_auth.admin.tsx
+++ b/apps/web/src/routes/_auth.admin.tsx
@@ -1,4 +1,5 @@
 import { createRoute } from '@tanstack/react-router';
+import { UserRole } from '@repo/types';
 
 import { requireRole } from '../lib/require-role';
 import { authRoute } from './_auth';
@@ -7,6 +8,6 @@ export const adminRoute = createRoute({
   getParentRoute: () => authRoute,
   id: '_admin',
   beforeLoad: () => {
-    requireRole(['ADMIN']);
+    requireRole([UserRole.ADMIN]);
   },
 });

--- a/apps/web/src/routes/routes.test.tsx
+++ b/apps/web/src/routes/routes.test.tsx
@@ -1,8 +1,11 @@
 import { createMemoryHistory, createRouter, RouterProvider } from '@tanstack/react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { UserRole } from '@repo/types';
+import type { ReactNode } from 'react';
 
 import { authRoute } from '../routes/_auth';
 import { adminRoute } from '../routes/_auth.admin';
@@ -18,10 +21,16 @@ const mockUser = {
   id: '01234567-89ab-7def-0123-456789abcdef',
   name: 'Ana Garcia',
   email: 'ana@example.com',
-  role: 'EMPLOYEE' as const,
+  role: UserRole.STANDARD,
+  isActive: true,
 };
 
-const server = setupServer();
+const mockAdminUser = {
+  ...mockUser,
+  role: UserRole.ADMIN,
+};
+
+const server = setupServer(http.get('*/users', () => HttpResponse.json([])));
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => {
@@ -43,6 +52,13 @@ function buildRouter(initialPath: string) {
   });
 }
 
+function Wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
 describe('Guard de navegacion: ruta autenticada', () => {
   it('redirige a /login cuando no hay sesion activa', async () => {
     server.use(
@@ -52,7 +68,7 @@ describe('Guard de navegacion: ruta autenticada', () => {
     );
 
     const router = buildRouter('/');
-    render(<RouterProvider router={router} />);
+    render(<RouterProvider router={router} />, { wrapper: Wrapper });
 
     await waitFor(() => {
       expect(screen.queryByText('Iniciar sesión')).toBeInTheDocument();
@@ -67,7 +83,7 @@ describe('Guard de navegacion: ruta autenticada', () => {
     );
 
     const router = buildRouter('/');
-    render(<RouterProvider router={router} />);
+    render(<RouterProvider router={router} />, { wrapper: Wrapper });
 
     await waitFor(() => {
       expect(screen.getByText('Dashboard')).toBeInTheDocument();
@@ -84,7 +100,7 @@ describe('Guard de navegacion: ruta publica', () => {
     );
 
     const router = buildRouter('/login');
-    render(<RouterProvider router={router} />);
+    render(<RouterProvider router={router} />, { wrapper: Wrapper });
 
     await waitFor(() => {
       expect(screen.getByText('Iniciar sesión')).toBeInTheDocument();
@@ -99,7 +115,7 @@ describe('Guard de navegacion: ruta publica', () => {
     );
 
     const router = buildRouter('/login');
-    render(<RouterProvider router={router} />);
+    render(<RouterProvider router={router} />, { wrapper: Wrapper });
 
     await waitFor(() => {
       expect(screen.getByText('Dashboard')).toBeInTheDocument();
@@ -109,18 +125,17 @@ describe('Guard de navegacion: ruta publica', () => {
 
 describe('Guard de rol: ruta de administracion', () => {
   it('muestra la pagina de admin cuando el usuario es ADMIN', async () => {
-    const adminUser = { ...mockUser, role: 'ADMIN' as const };
     server.use(
       http.get('*/auth/me', () => {
-        return HttpResponse.json(adminUser);
+        return HttpResponse.json(mockAdminUser);
       })
     );
 
     const router = buildRouter('/admin');
-    render(<RouterProvider router={router} />);
+    render(<RouterProvider router={router} />, { wrapper: Wrapper });
 
     await waitFor(() => {
-      expect(screen.getByText('Administración')).toBeInTheDocument();
+      expect(screen.getByText('Usuarios')).toBeInTheDocument();
     });
   });
 
@@ -132,7 +147,7 @@ describe('Guard de rol: ruta de administracion', () => {
     );
 
     const router = buildRouter('/admin');
-    render(<RouterProvider router={router} />);
+    render(<RouterProvider router={router} />, { wrapper: Wrapper });
 
     await waitFor(() => {
       expect(screen.getByText('Acceso no permitido')).toBeInTheDocument();

--- a/apps/web/src/store/auth.store.test.ts
+++ b/apps/web/src/store/auth.store.test.ts
@@ -1,14 +1,14 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { useAuthStore } from './auth.store';
+import { UserRole, useAuthStore } from './auth.store';
 import type { SessionUser } from './auth.store';
 
 const mockUser: SessionUser = {
   id: '01900000-0000-7000-8000-000000000001',
   name: 'Ana Garcia',
   email: 'ana@example.com',
-  role: 'EMPLOYEE',
+  role: UserRole.STANDARD,
   isActive: true,
 };
 
@@ -112,7 +112,7 @@ describe('useAuthStore: SessionUser campos minimos', () => {
       id: 'some-uuid',
       name: 'Test User',
       email: 'test@example.com',
-      role: 'VALIDATOR',
+      role: UserRole.VALIDATOR,
       isActive: true,
     };
 

--- a/apps/web/src/store/auth.store.ts
+++ b/apps/web/src/store/auth.store.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
+import type { UserRole } from '@repo/types';
 
-export type UserRole = 'EMPLOYEE' | 'VALIDATOR' | 'AUDITOR' | 'ADMIN';
+export { UserRole } from '@repo/types';
 
 export interface SessionUser {
   id: string;


### PR DESCRIPTION
## Summary

- Implements the admin user list table (issue #53)
- Fixes `UserRole` enum usage throughout the frontend (was using wrong uppercase literals)
- Adds `UserTable` component with loading/error/empty states, role badges, and active/inactive indicator
- Adds `use-users` hook via TanStack Query and `users.keys` query key factory

## Changes

### Fixed
- `auth.store.ts`: re-exports `UserRole` from `@repo/types` using `export { UserRole } from` syntax (fixes `unicorn/prefer-export-from` lint rule)
- `_auth.admin.tsx`: uses `UserRole.ADMIN` enum value instead of uppercase string literal
- All test files updated to use correct lowercase `UserRole` enum values

### Added
- `apps/web/src/lib/query-keys/users.keys.ts` — query key factory for users
- `apps/web/src/hooks/use-users.ts` — TanStack Query hook fetching `GET /users`
- `apps/web/src/components/users/UserTable.tsx` — user list table with empty state
- `apps/web/src/components/users/UserTable.test.tsx` — 6 tests covering all render states

### Updated
- `apps/web/src/lib/api-client.ts` — adds `listUsers()` function
- `apps/web/src/pages/admin/AdminPage.tsx` — full implementation with loading/error/success states

## Tests

All 53 tests pass. Lint and typecheck clean.

Closes #53