### PR TITLE
fix(types): Switches @repo/types build to CommonJS to fix Node.js module resolution

### DIFF
--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "../config/tsconfig.base.json",
   "compilerOptions": {
+    "module": "CommonJS",
+    "moduleResolution": "Node",
     "outDir": "dist",
     "rootDir": "src",
     "declaration": true,


### PR DESCRIPTION
## Problem

The backend crashes on startup with:

```
Cannot find module '/workspace/packages/types/dist/enums'
imported from /workspace/packages/types/dist/index.js
```

## Root cause

`packages/types/tsconfig.json` inherits `module: ESNext` / `moduleResolution: Bundler` from the base config. With those settings TypeScript emits extensionless re-exports:

```js
// dist/index.js (ESM output)
export * from './enums';   // ← no .js extension
```

Bundlers (Vite) resolve this at build time without issues. But Node.js CJS/ESM runtime cannot find `./enums` without an extension — it expects `./enums.js` or a directory with `index.js`.

## Fix

Override `module` and `moduleResolution` in `packages/types/tsconfig.json` to `CommonJS` / `Node`. The emitted output becomes:

```js
// dist/index.js (CJS output)
__exportStar(require("./enums"), exports);  // ← Node.js resolves this correctly
```

The web app (`apps/web`) is unaffected: Vite resolves `@repo/types` via `tsconfig paths` directly to `packages/types/src/index.ts`, never touching the `dist/` output.