### PR TITLE
fix(web): Resolves blank app by aliasing @repo/types to TypeScript source in Vite

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -6,7 +6,8 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": ["vite/client"],
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["src/*"],
+      "@repo/types": ["../../packages/types/src/index.ts"]
     }
   },
   "include": ["src"]

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),
+      '@repo/types': path.resolve(__dirname, '../../packages/types/src/index.ts'),
     },
   },
   envDir: path.resolve(__dirname, '../..'),


### PR DESCRIPTION
## Causa raíz

La pantalla en blanco recurrente tenía **dos bugs entrelazados**:

1. **`apps/web/tsconfig.json` sobreescribía `paths` incompletamente.** Al declarar `"paths": { "@/*": ["src/*"] }`, TypeScript eliminaba silenciosamente el path `@repo/types` heredado de `tsconfig.base.json`. Esto no rompía el typecheck (tsc resuelve el paquete via `node_modules`), pero sí afectaba a la coherencia.

2. **Vite/Rollup consumía el dist CJS de `@repo/types` como si fuera ESM.** Como no había alias en `vite.config.ts`, Vite resolvía `@repo/types` via `node_modules` → `package.json` → `dist/index.js` (CommonJS). Rollup no puede extraer named exports de módulos CJS al hacer el bundle ESM → el import de `UserRole` y otros enums fallaba en runtime → pantalla en blanco.

## Solución

- **`apps/web/vite.config.ts`**: añade alias `@repo/types` → `packages/types/src/index.ts`. Vite ahora transpila el source TypeScript directamente, igual que lo hace con el código del propio frontend. El dist de `@repo/types` queda reservado exclusivamente para el backend (Node.js / NestJS).

- **`apps/web/tsconfig.json`**: añade `@repo/types` al `paths` local para que la resolución de TypeScript sea consistente con la de Vite.

## Por qué es definitivo

El frontend ya no depende del formato de salida de `@repo/types` (CJS, ESM, o cualquier otro). Cualquier cambio futuro en el tsconfig o en el build del paquete `types` no afectará al bundler web.

## Verificación

- `vite build` → ✅ sin errores
- `tsc --noEmit` → ✅ sin errores  
- `eslint` → ✅ sin warnings
- `vitest run` → ✅ 63/63 tests

Closes #177