### PR TITLE
[Frontend] Hooks users queries/mutations

### DIFF
--- a/apps/web/src/hooks/use-users.ts
+++ b/apps/web/src/hooks/use-users.ts
@@ -1,7 +1,13 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { User } from '@repo/types';
 
-import { listUsers } from '../lib/api-client';
+import {
+  createUser,
+  listUsers,
+  updateUser,
+  type CreateUserPayload,
+  type UpdateUserPayload,
+} from '../lib/api-client';
 import { usersKeys } from '../lib/query-keys/users.keys';
 
 export function useUsers() {
@@ -12,4 +18,28 @@ export function useUsers() {
   });
 
   return { users: data ?? [], isLoading, isError, error };
+}
+
+export function useCreateUser() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: CreateUserPayload) => createUser(payload),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: usersKeys.list() });
+    },
+  });
+}
+
+export function useUpdateUser() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, payload }: { id: string; payload: UpdateUserPayload }) =>
+      updateUser(id, payload),
+    onSuccess: (_, { id }) => {
+      queryClient.invalidateQueries({ queryKey: usersKeys.list() });
+      queryClient.invalidateQueries({ queryKey: usersKeys.detail(id) });
+    },
+  });
 }


### PR DESCRIPTION
## Summary

- Adds `useCreateUser` mutation hook for creating new users
- Adds `useUpdateUser` mutation hook for updating existing users
- Both hooks properly invalidate TanStack Query cache on success
- Follows established patterns for query keys and mutation hooks

## Changes

- Extended `apps/web/src/hooks/use-users.ts` with two new mutation hooks
- `useCreateUser`: Creates a new user and invalidates the users list cache
- `useUpdateUser`: Updates an existing user and invalidates both the users list and the specific user detail cache

## Testing

- TypeScript compilation: ✅ Passes
- ESLint: ✅ Passes
- Manual testing: Pending (to be done by reviewer)

## Related

Closes #55