### PR TITLE
feat(observation): Adds observation creation and listing endpoints

### DIFF
--- a/apps/api/src/modules/app.module.ts
+++ b/apps/api/src/modules/app.module.ts
@@ -10,6 +10,7 @@ import { envValidationSchema } from '../config';
 import { AuthModule } from './auth';
 import { UsersModule } from './users/users.module';
 import { AbsenceTypesModule } from './absence-types/absence-types.module';
+import { ObservationsModule } from './observations/observations.module';
 
 @Module({
   imports: [
@@ -22,6 +23,7 @@ import { AbsenceTypesModule } from './absence-types/absence-types.module';
     PrismaModule,
     UsersModule,
     AbsenceTypesModule,
+    ObservationsModule,
   ],
   providers: [
     ClockService,

--- a/apps/api/src/modules/observations/application/commands/create-observation.command.ts
+++ b/apps/api/src/modules/observations/application/commands/create-observation.command.ts
@@ -1,0 +1,12 @@
+/**
+ * Command to create a new observation on an absence.
+ *
+ * Implements RF-35 (observation section) and RF-36 (only involved users can create).
+ */
+export class CreateObservationCommand {
+  constructor(
+    public readonly absenceId: string,
+    public readonly userId: string,
+    public readonly content: string
+  ) {}
+}

--- a/apps/api/src/modules/observations/application/commands/create-observation.handler.spec.ts
+++ b/apps/api/src/modules/observations/application/commands/create-observation.handler.spec.ts
@@ -1,0 +1,177 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+
+import { ClockService, generateId } from '../../../../common';
+import { Observation } from '../../domain/observation.entity';
+import type { ObservationRepositoryPort } from '../../domain/ports/observation.repository.port';
+import { Absence } from '../../../absences/domain/absence.entity';
+import type { AbsenceRepositoryPort } from '../../../absences/domain/ports/absence.repository.port';
+import { CreateObservationCommand } from './create-observation.command';
+import { CreateObservationHandler } from './create-observation.handler';
+
+const NOW = new Date('2025-01-01T00:00:00.000Z');
+
+const makeObservationRepo = (
+  overrides: Partial<ObservationRepositoryPort> = {}
+): ObservationRepositoryPort => ({
+  save: jest.fn(),
+  findByAbsenceId: jest.fn(),
+  ...overrides,
+});
+
+const makeAbsenceRepo = (
+  overrides: Partial<AbsenceRepositoryPort> = {}
+): AbsenceRepositoryPort => ({
+  findById: jest.fn(),
+  save: jest.fn(),
+  update: jest.fn(),
+  createStatusHistory: jest.fn(),
+  calculateConsumedByUserAndTypeInYear: jest.fn(),
+  hasOverlap: jest.fn(),
+  ...overrides,
+});
+
+const makeClockService = (): ClockService => ({
+  now: jest.fn().mockReturnValue(NOW),
+});
+
+const makeAbsence = (overrides: Partial<Absence> = {}): Absence =>
+  new Absence({
+    id: 'absence-id',
+    userId: 'creator-id',
+    absenceTypeId: 'type-id',
+    startAt: new Date('2025-02-01'),
+    endAt: new Date('2025-02-05'),
+    duration: 5,
+    status: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  });
+
+// Mock generateId to return predictable values
+jest.mock('../../../../common', () => ({
+  ...jest.requireActual('../../../../common'),
+  generateId: jest.fn(),
+}));
+
+describe('CreateObservationHandler', () => {
+  beforeEach(() => {
+    (generateId as jest.Mock).mockReturnValue('generated-observation-id');
+  });
+
+  it('successfully creates observation when user is creator', async () => {
+    const absence = makeAbsence({ userId: 'creator-id' });
+    const absenceRepo = makeAbsenceRepo({
+      findById: jest.fn().mockResolvedValue(absence),
+    });
+    const observationRepo = makeObservationRepo();
+    const clock = makeClockService();
+    const handler = new CreateObservationHandler(observationRepo, absenceRepo, clock);
+    const command = new CreateObservationCommand('absence-id', 'creator-id', 'This is a note');
+
+    const result = await handler.execute(command);
+
+    expect(result).toBe('generated-observation-id');
+    expect(absenceRepo.findById).toHaveBeenCalledWith('absence-id');
+    expect(observationRepo.save).toHaveBeenCalledTimes(1);
+    const savedObservation = (observationRepo.save as jest.Mock).mock.calls[0][0] as Observation;
+    expect(savedObservation.id).toBe('generated-observation-id');
+    expect(savedObservation.absenceId).toBe('absence-id');
+    expect(savedObservation.userId).toBe('creator-id');
+    expect(savedObservation.content).toBe('This is a note');
+    expect(savedObservation.createdAt).toEqual(NOW);
+  });
+
+  it('throws ForbiddenException when user is not creator', async () => {
+    const absence = makeAbsence({ userId: 'creator-id' });
+    const absenceRepo = makeAbsenceRepo({
+      findById: jest.fn().mockResolvedValue(absence),
+    });
+    const observationRepo = makeObservationRepo();
+    const clock = makeClockService();
+    const handler = new CreateObservationHandler(observationRepo, absenceRepo, clock);
+    const command = new CreateObservationCommand(
+      'absence-id',
+      'other-user-id',
+      'I should not be able to post'
+    );
+
+    await expect(handler.execute(command)).rejects.toThrow(ForbiddenException);
+    await expect(handler.execute(command)).rejects.toThrow(
+      'Only involved users can create observations on this absence'
+    );
+    expect(observationRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('throws NotFoundException when absence does not exist', async () => {
+    const absenceRepo = makeAbsenceRepo({
+      findById: jest.fn().mockResolvedValue(null),
+    });
+    const observationRepo = makeObservationRepo();
+    const clock = makeClockService();
+    const handler = new CreateObservationHandler(observationRepo, absenceRepo, clock);
+    const command = new CreateObservationCommand('non-existent-id', 'user-id', 'Content');
+
+    await expect(handler.execute(command)).rejects.toThrow(NotFoundException);
+    await expect(handler.execute(command)).rejects.toThrow(
+      'Absence with ID non-existent-id not found'
+    );
+    expect(observationRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('throws ForbiddenException when user is not creator', async () => {
+    const absence = makeAbsence({ userId: 'creator-id' });
+    const absenceRepo = makeAbsenceRepo({
+      findById: jest.fn().mockResolvedValue(absence),
+    });
+    const observationRepo = makeObservationRepo();
+    const clock = makeClockService();
+    const handler = new CreateObservationHandler(observationRepo, absenceRepo, clock);
+    const command = new CreateObservationCommand(
+      'absence-id',
+      'uninvolved-user-id',
+      'I should not be able to post'
+    );
+
+    await expect(handler.execute(command)).rejects.toThrow(ForbiddenException);
+    await expect(handler.execute(command)).rejects.toThrow(
+      'Only involved users can create observations on this absence'
+    );
+    expect(observationRepo.save).not.toHaveBeenCalled();
+  });
+
+  it('uses ClockService for timestamp', async () => {
+    const customTime = new Date('2025-06-15T12:30:00.000Z');
+    const absence = makeAbsence({ userId: 'creator-id' });
+    const absenceRepo = makeAbsenceRepo({
+      findById: jest.fn().mockResolvedValue(absence),
+    });
+    const observationRepo = makeObservationRepo();
+    const clock = { now: jest.fn().mockReturnValue(customTime) };
+    const handler = new CreateObservationHandler(observationRepo, absenceRepo, clock);
+    const command = new CreateObservationCommand('absence-id', 'creator-id', 'Content');
+
+    await handler.execute(command);
+
+    expect(clock.now).toHaveBeenCalledTimes(1);
+    const savedObservation = (observationRepo.save as jest.Mock).mock.calls[0][0] as Observation;
+    expect(savedObservation.createdAt).toEqual(customTime);
+  });
+
+  it('uses generateId for observation ID', async () => {
+    (generateId as jest.Mock).mockReturnValue('custom-generated-id');
+    const absence = makeAbsence({ userId: 'creator-id' });
+    const absenceRepo = makeAbsenceRepo({
+      findById: jest.fn().mockResolvedValue(absence),
+    });
+    const observationRepo = makeObservationRepo();
+    const clock = makeClockService();
+    const handler = new CreateObservationHandler(observationRepo, absenceRepo, clock);
+    const command = new CreateObservationCommand('absence-id', 'creator-id', 'Content');
+
+    const result = await handler.execute(command);
+
+    expect(result).toBe('custom-generated-id');
+    expect(generateId).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/api/src/modules/observations/application/commands/create-observation.handler.ts
+++ b/apps/api/src/modules/observations/application/commands/create-observation.handler.ts
@@ -1,0 +1,64 @@
+import { ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { CommandHandler, ICommandHandler } from '@nestjs/cqrs';
+
+import { ClockService, generateId } from '../../../../common';
+import { Observation } from '../../domain/observation.entity';
+import {
+  OBSERVATION_REPOSITORY_PORT,
+  ObservationRepositoryPort,
+} from '../../domain/ports/observation.repository.port';
+import { ABSENCE_REPOSITORY_PORT } from '../../../absences/domain/ports/absence.repository.port';
+import type { AbsenceRepositoryPort } from '../../../absences/domain/ports/absence.repository.port';
+import { CreateObservationCommand } from './create-observation.command';
+
+/**
+ * Command handler for creating a new observation on an absence.
+ *
+ * Implements:
+ * - RF-35: Observation section on absences
+ * - RF-36: Only involved users (creator + validators) can create observations
+ * - RF-37: Observations can be used to explain approvals/rejections
+ */
+@Injectable()
+@CommandHandler(CreateObservationCommand)
+export class CreateObservationHandler implements ICommandHandler<CreateObservationCommand, string> {
+  constructor(
+    @Inject(OBSERVATION_REPOSITORY_PORT)
+    private readonly observationRepository: ObservationRepositoryPort,
+    @Inject(ABSENCE_REPOSITORY_PORT)
+    private readonly absenceRepository: AbsenceRepositoryPort,
+    private readonly clock: ClockService
+  ) {}
+
+  async execute(command: CreateObservationCommand): Promise<string> {
+    const now = this.clock.now();
+
+    // Verify absence exists
+    const absence = await this.absenceRepository.findById(command.absenceId);
+    if (!absence) {
+      throw new NotFoundException(`Absence with ID ${command.absenceId} not found`);
+    }
+
+    // RF-36: Verify user is involved (creator or validator)
+    // TODO: Add validator check when validation flow is implemented (phase 7)
+    const isCreator = absence.userId === command.userId;
+
+    if (!isCreator) {
+      throw new ForbiddenException('Only involved users can create observations on this absence');
+    }
+
+    // Create observation
+    const observationId = generateId();
+    const observation = new Observation({
+      id: observationId,
+      absenceId: command.absenceId,
+      userId: command.userId,
+      content: command.content,
+      createdAt: now,
+    });
+
+    await this.observationRepository.save(observation);
+
+    return observationId;
+  }
+}

--- a/apps/api/src/modules/observations/application/dtos/create-observation.dto.ts
+++ b/apps/api/src/modules/observations/application/dtos/create-observation.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, MinLength } from 'class-validator';
+
+export class CreateObservationDto {
+  @IsString()
+  @MinLength(1)
+  content!: string;
+}

--- a/apps/api/src/modules/observations/application/dtos/observation-response.dto.ts
+++ b/apps/api/src/modules/observations/application/dtos/observation-response.dto.ts
@@ -1,0 +1,7 @@
+export interface ObservationResponseDto {
+  id: string;
+  absenceId: string;
+  userId: string;
+  content: string;
+  createdAt: string;
+}

--- a/apps/api/src/modules/observations/application/queries/list-observations.handler.spec.ts
+++ b/apps/api/src/modules/observations/application/queries/list-observations.handler.spec.ts
@@ -1,0 +1,190 @@
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+
+import { Observation } from '../../domain/observation.entity';
+import type { ObservationRepositoryPort } from '../../domain/ports/observation.repository.port';
+import { Absence } from '../../../absences/domain/absence.entity';
+import type { AbsenceRepositoryPort } from '../../../absences/domain/ports/absence.repository.port';
+import { ObservationMapper } from '../../infrastructure/observation.mapper';
+import { ListObservationsQuery } from './list-observations.query';
+import { ListObservationsHandler } from './list-observations.handler';
+
+const NOW = new Date('2025-01-01T00:00:00.000Z');
+const LATER = new Date('2025-01-01T12:00:00.000Z');
+
+const makeObservationRepo = (
+  overrides: Partial<ObservationRepositoryPort> = {}
+): ObservationRepositoryPort => ({
+  save: jest.fn(),
+  findByAbsenceId: jest.fn().mockResolvedValue([]),
+  ...overrides,
+});
+
+const makeAbsenceRepo = (
+  overrides: Partial<AbsenceRepositoryPort> = {}
+): AbsenceRepositoryPort => ({
+  findById: jest.fn(),
+  save: jest.fn(),
+  update: jest.fn(),
+  createStatusHistory: jest.fn(),
+  calculateConsumedByUserAndTypeInYear: jest.fn(),
+  hasOverlap: jest.fn(),
+  ...overrides,
+});
+
+const makeAbsence = (overrides: Partial<Absence> = {}): Absence =>
+  new Absence({
+    id: 'absence-id',
+    userId: 'creator-id',
+    absenceTypeId: 'type-id',
+    startAt: new Date('2025-02-01'),
+    endAt: new Date('2025-02-05'),
+    duration: 5,
+    status: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  });
+
+const makeObservation = (overrides: Partial<Observation> = {}): Observation =>
+  new Observation({
+    id: 'observation-id',
+    absenceId: 'absence-id',
+    userId: 'user-id',
+    content: 'Test observation',
+    createdAt: NOW,
+    ...overrides,
+  });
+
+describe('ListObservationsHandler', () => {
+  it('successfully lists observations when user is creator', async () => {
+    const absence = makeAbsence({ userId: 'creator-id' });
+    const observation1 = makeObservation({
+      id: 'obs-1',
+      userId: 'creator-id',
+      content: 'First note',
+      createdAt: NOW,
+    });
+    const observation2 = makeObservation({
+      id: 'obs-2',
+      userId: 'creator-id',
+      content: 'Second note',
+      createdAt: LATER,
+    });
+    const absenceRepo = makeAbsenceRepo({
+      findById: jest.fn().mockResolvedValue(absence),
+    });
+    const observationRepo = makeObservationRepo({
+      findByAbsenceId: jest.fn().mockResolvedValue([observation1, observation2]),
+    });
+    const mapper = new ObservationMapper();
+    const handler = new ListObservationsHandler(observationRepo, absenceRepo, mapper);
+    const query = new ListObservationsQuery('absence-id', 'creator-id');
+
+    const result = await handler.execute(query);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('obs-1');
+    expect(result[0].content).toBe('First note');
+    expect(result[1].id).toBe('obs-2');
+    expect(result[1].content).toBe('Second note');
+    expect(absenceRepo.findById).toHaveBeenCalledWith('absence-id');
+    expect(observationRepo.findByAbsenceId).toHaveBeenCalledWith('absence-id');
+  });
+
+  it('throws ForbiddenException when user is not creator', async () => {
+    const absence = makeAbsence({ userId: 'creator-id' });
+    const absenceRepo = makeAbsenceRepo({
+      findById: jest.fn().mockResolvedValue(absence),
+    });
+    const observationRepo = makeObservationRepo();
+    const mapper = new ObservationMapper();
+    const handler = new ListObservationsHandler(observationRepo, absenceRepo, mapper);
+    const query = new ListObservationsQuery('absence-id', 'other-user-id');
+
+    await expect(handler.execute(query)).rejects.toThrow(ForbiddenException);
+    await expect(handler.execute(query)).rejects.toThrow(
+      'Only involved users can view observations on this absence'
+    );
+    expect(observationRepo.findByAbsenceId).not.toHaveBeenCalled();
+  });
+
+  it('throws NotFoundException when absence does not exist', async () => {
+    const absenceRepo = makeAbsenceRepo({
+      findById: jest.fn().mockResolvedValue(null),
+    });
+    const observationRepo = makeObservationRepo();
+    const mapper = new ObservationMapper();
+    const handler = new ListObservationsHandler(observationRepo, absenceRepo, mapper);
+    const query = new ListObservationsQuery('non-existent-id', 'user-id');
+
+    await expect(handler.execute(query)).rejects.toThrow(NotFoundException);
+    await expect(handler.execute(query)).rejects.toThrow(
+      'Absence with ID non-existent-id not found'
+    );
+    expect(observationRepo.findByAbsenceId).not.toHaveBeenCalled();
+  });
+
+  it('throws ForbiddenException when user is not creator', async () => {
+    const absence = makeAbsence({ userId: 'creator-id' });
+    const absenceRepo = makeAbsenceRepo({
+      findById: jest.fn().mockResolvedValue(absence),
+    });
+    const observationRepo = makeObservationRepo();
+    const mapper = new ObservationMapper();
+    const handler = new ListObservationsHandler(observationRepo, absenceRepo, mapper);
+    const query = new ListObservationsQuery('absence-id', 'uninvolved-user-id');
+
+    await expect(handler.execute(query)).rejects.toThrow(ForbiddenException);
+    await expect(handler.execute(query)).rejects.toThrow(
+      'Only involved users can view observations on this absence'
+    );
+    expect(observationRepo.findByAbsenceId).not.toHaveBeenCalled();
+  });
+
+  it('returns empty array when no observations exist', async () => {
+    const absence = makeAbsence({ userId: 'creator-id' });
+    const absenceRepo = makeAbsenceRepo({
+      findById: jest.fn().mockResolvedValue(absence),
+    });
+    const observationRepo = makeObservationRepo({
+      findByAbsenceId: jest.fn().mockResolvedValue([]),
+    });
+    const mapper = new ObservationMapper();
+    const handler = new ListObservationsHandler(observationRepo, absenceRepo, mapper);
+    const query = new ListObservationsQuery('absence-id', 'creator-id');
+
+    const result = await handler.execute(query);
+
+    expect(result).toEqual([]);
+    expect(observationRepo.findByAbsenceId).toHaveBeenCalledWith('absence-id');
+  });
+
+  it('maps observations using ObservationMapper', async () => {
+    const absence = makeAbsence({ userId: 'creator-id' });
+    const observation = makeObservation({
+      id: 'obs-1',
+      userId: 'creator-id',
+      content: 'Test content',
+      createdAt: NOW,
+    });
+    const absenceRepo = makeAbsenceRepo({
+      findById: jest.fn().mockResolvedValue(absence),
+    });
+    const observationRepo = makeObservationRepo({
+      findByAbsenceId: jest.fn().mockResolvedValue([observation]),
+    });
+    const mapper = new ObservationMapper();
+    const mapperSpy = jest.spyOn(mapper, 'toResponseDto');
+    const handler = new ListObservationsHandler(observationRepo, absenceRepo, mapper);
+    const query = new ListObservationsQuery('absence-id', 'creator-id');
+
+    const result = await handler.execute(query);
+
+    expect(mapperSpy).toHaveBeenCalledTimes(1);
+    expect(mapperSpy).toHaveBeenCalledWith(observation);
+    expect(result[0].id).toBe('obs-1');
+    expect(result[0].userId).toBe('creator-id');
+    expect(result[0].content).toBe('Test content');
+    expect(result[0].createdAt).toBe(NOW.toISOString());
+  });
+});

--- a/apps/api/src/modules/observations/application/queries/list-observations.handler.ts
+++ b/apps/api/src/modules/observations/application/queries/list-observations.handler.ts
@@ -1,0 +1,55 @@
+import { ForbiddenException, Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+
+import {
+  OBSERVATION_REPOSITORY_PORT,
+  ObservationRepositoryPort,
+} from '../../domain/ports/observation.repository.port';
+import { ABSENCE_REPOSITORY_PORT } from '../../../absences/domain/ports/absence.repository.port';
+import type { AbsenceRepositoryPort } from '../../../absences/domain/ports/absence.repository.port';
+import { ObservationMapper } from '../../infrastructure/observation.mapper';
+import type { ObservationResponseDto } from '../dtos/observation-response.dto';
+import { ListObservationsQuery } from './list-observations.query';
+
+/**
+ * Query handler for listing observations of an absence.
+ *
+ * Implements:
+ * - RF-35: Observation section on absences
+ * - RF-36: Only involved users (creator + validators) can view observations
+ */
+@Injectable()
+@QueryHandler(ListObservationsQuery)
+export class ListObservationsHandler implements IQueryHandler<
+  ListObservationsQuery,
+  ObservationResponseDto[]
+> {
+  constructor(
+    @Inject(OBSERVATION_REPOSITORY_PORT)
+    private readonly observationRepository: ObservationRepositoryPort,
+    @Inject(ABSENCE_REPOSITORY_PORT)
+    private readonly absenceRepository: AbsenceRepositoryPort,
+    private readonly mapper: ObservationMapper
+  ) {}
+
+  async execute(query: ListObservationsQuery): Promise<ObservationResponseDto[]> {
+    // Verify absence exists
+    const absence = await this.absenceRepository.findById(query.absenceId);
+    if (!absence) {
+      throw new NotFoundException(`Absence with ID ${query.absenceId} not found`);
+    }
+
+    // RF-36: Verify user is involved (creator or validator)
+    // TODO: Add validator check when validation flow is implemented (phase 7)
+    const isCreator = absence.userId === query.userId;
+
+    if (!isCreator) {
+      throw new ForbiddenException('Only involved users can view observations on this absence');
+    }
+
+    // Retrieve and map observations
+    const observations = await this.observationRepository.findByAbsenceId(query.absenceId);
+
+    return observations.map((observation) => this.mapper.toResponseDto(observation));
+  }
+}

--- a/apps/api/src/modules/observations/application/queries/list-observations.query.ts
+++ b/apps/api/src/modules/observations/application/queries/list-observations.query.ts
@@ -1,0 +1,11 @@
+/**
+ * Query to list all observations for a specific absence.
+ *
+ * Implements RF-35 (observation section) and RF-36 (only involved users can view).
+ */
+export class ListObservationsQuery {
+  constructor(
+    public readonly absenceId: string,
+    public readonly userId: string
+  ) {}
+}

--- a/apps/api/src/modules/observations/domain/observation.entity.ts
+++ b/apps/api/src/modules/observations/domain/observation.entity.ts
@@ -1,0 +1,29 @@
+export interface ObservationProps {
+  id: string;
+  absenceId: string;
+  userId: string;
+  content: string;
+  createdAt: Date;
+}
+
+/**
+ * Observation domain entity.
+ *
+ * Represents a comment or note added to an absence by an involved user.
+ * Implements RF-35 (observation section on absences).
+ */
+export class Observation {
+  readonly id: string;
+  readonly absenceId: string;
+  readonly userId: string;
+  readonly content: string;
+  readonly createdAt: Date;
+
+  constructor(props: ObservationProps) {
+    this.id = props.id;
+    this.absenceId = props.absenceId;
+    this.userId = props.userId;
+    this.content = props.content;
+    this.createdAt = props.createdAt;
+  }
+}

--- a/apps/api/src/modules/observations/domain/ports/observation.repository.port.ts
+++ b/apps/api/src/modules/observations/domain/ports/observation.repository.port.ts
@@ -1,0 +1,20 @@
+import type { Observation } from '../observation.entity';
+
+export interface ObservationRepositoryPort {
+  /**
+   * Saves a new observation to the database.
+   *
+   * @param observation - The observation entity to save
+   */
+  save(observation: Observation): Promise<void>;
+
+  /**
+   * Finds all observations for a specific absence, ordered by creation date.
+   *
+   * @param absenceId - The ID of the absence
+   * @returns Array of observations ordered by createdAt ascending
+   */
+  findByAbsenceId(absenceId: string): Promise<Observation[]>;
+}
+
+export const OBSERVATION_REPOSITORY_PORT = Symbol('ObservationRepositoryPort');

--- a/apps/api/src/modules/observations/infrastructure/observation.mapper.ts
+++ b/apps/api/src/modules/observations/infrastructure/observation.mapper.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import type { observation as PrismaObservation } from '@prisma/client';
+
+import { Observation } from '../domain/observation.entity';
+import type { ObservationResponseDto } from '../application/dtos/observation-response.dto';
+
+@Injectable()
+export class ObservationMapper {
+  toDomain(prismaObservation: PrismaObservation): Observation {
+    return new Observation({
+      id: prismaObservation.id,
+      absenceId: prismaObservation.absence_id,
+      userId: prismaObservation.user_id,
+      content: prismaObservation.content,
+      createdAt: prismaObservation.created_at,
+    });
+  }
+
+  toResponseDto(observation: Observation): ObservationResponseDto {
+    return {
+      id: observation.id,
+      absenceId: observation.absenceId,
+      userId: observation.userId,
+      content: observation.content,
+      createdAt: observation.createdAt.toISOString(),
+    };
+  }
+}

--- a/apps/api/src/modules/observations/infrastructure/observation.prisma.repository.ts
+++ b/apps/api/src/modules/observations/infrastructure/observation.prisma.repository.ts
@@ -1,0 +1,35 @@
+import { Injectable } from '@nestjs/common';
+
+import { PrismaService } from '../../../prisma/prisma.service';
+import { Observation } from '../domain/observation.entity';
+import type { ObservationRepositoryPort } from '../domain/ports/observation.repository.port';
+import { ObservationMapper } from './observation.mapper';
+
+@Injectable()
+export class ObservationPrismaRepository implements ObservationRepositoryPort {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly mapper: ObservationMapper
+  ) {}
+
+  async save(observation: Observation): Promise<void> {
+    await this.prisma.observation.create({
+      data: {
+        id: observation.id,
+        absence_id: observation.absenceId,
+        user_id: observation.userId,
+        content: observation.content,
+        created_at: observation.createdAt,
+      },
+    });
+  }
+
+  async findByAbsenceId(absenceId: string): Promise<Observation[]> {
+    const records = await this.prisma.observation.findMany({
+      where: { absence_id: absenceId },
+      orderBy: { created_at: 'asc' },
+    });
+
+    return records.map((record) => this.mapper.toDomain(record));
+  }
+}

--- a/apps/api/src/modules/observations/infrastructure/observations.controller.ts
+++ b/apps/api/src/modules/observations/infrastructure/observations.controller.ts
@@ -1,0 +1,65 @@
+import { Body, Controller, Get, Param, Post, Req, UseGuards } from '@nestjs/common';
+import { CommandBus, QueryBus } from '@nestjs/cqrs';
+import type { Request } from 'express';
+
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import type { ObservationResponseDto } from '../application/dtos/observation-response.dto';
+import { CreateObservationDto } from '../application/dtos/create-observation.dto';
+import { CreateObservationCommand } from '../application/commands/create-observation.command';
+import { ListObservationsQuery } from '../application/queries/list-observations.query';
+
+/**
+ * Controller for observation endpoints.
+ *
+ * Implements RF-35 (observation section) and RF-36 (access control).
+ */
+@UseGuards(JwtAuthGuard)
+@Controller('absences/:absenceId/observations')
+export class ObservationsController {
+  constructor(
+    private readonly commandBus: CommandBus,
+    private readonly queryBus: QueryBus
+  ) {}
+
+  /**
+   * Creates a new observation on an absence.
+   *
+   * POST /absences/:absenceId/observations
+   *
+   * RF-36: Only involved users (creator + validators) can create observations.
+   */
+  @Post()
+  async create(
+    @Param('absenceId') absenceId: string,
+    @Body() dto: CreateObservationDto,
+    @Req() request: Request
+  ): Promise<{ id: string }> {
+    const user = request.user as { userId: string };
+
+    const id = await this.commandBus.execute<CreateObservationCommand, string>(
+      new CreateObservationCommand(absenceId, user.userId, dto.content)
+    );
+
+    return { id };
+  }
+
+  /**
+   * Lists all observations for an absence.
+   *
+   * GET /absences/:absenceId/observations
+   *
+   * RF-36: Only involved users (creator + validators) can view observations.
+   * Ordered by created_at ascending.
+   */
+  @Get()
+  async findAll(
+    @Param('absenceId') absenceId: string,
+    @Req() request: Request
+  ): Promise<ObservationResponseDto[]> {
+    const user = request.user as { userId: string };
+
+    return this.queryBus.execute<ListObservationsQuery, ObservationResponseDto[]>(
+      new ListObservationsQuery(absenceId, user.userId)
+    );
+  }
+}

--- a/apps/api/src/modules/observations/observations.module.ts
+++ b/apps/api/src/modules/observations/observations.module.ts
@@ -1,0 +1,35 @@
+import { Module } from '@nestjs/common';
+import { CqrsModule } from '@nestjs/cqrs';
+
+import { ClockService } from '../../common';
+import { PrismaModule } from '../../prisma/prisma.module';
+import { AbsencesModule } from '../absences/absences.module';
+import { OBSERVATION_REPOSITORY_PORT } from './domain/ports/observation.repository.port';
+import { ObservationPrismaRepository } from './infrastructure/observation.prisma.repository';
+import { ObservationMapper } from './infrastructure/observation.mapper';
+import { ObservationsController } from './infrastructure/observations.controller';
+import { CreateObservationHandler } from './application/commands/create-observation.handler';
+import { ListObservationsHandler } from './application/queries/list-observations.handler';
+
+const commandHandlers = [CreateObservationHandler];
+const queryHandlers = [ListObservationsHandler];
+
+@Module({
+  imports: [CqrsModule, PrismaModule, AbsencesModule],
+  controllers: [ObservationsController],
+  providers: [
+    ClockService,
+    // Repository
+    {
+      provide: OBSERVATION_REPOSITORY_PORT,
+      useClass: ObservationPrismaRepository,
+    },
+    // Mapper
+    ObservationMapper,
+    // Handlers
+    ...commandHandlers,
+    ...queryHandlers,
+  ],
+  exports: [OBSERVATION_REPOSITORY_PORT],
+})
+export class ObservationsModule {}


### PR DESCRIPTION
## Summary

Implements **RF-35, RF-36 (partial), and RF-37** for absence observations.

This PR adds backend functionality that allows users involved in an absence to add and view observations (comments). Currently, only the absence creator can add/view observations. The validator check will be added when the validation flow is implemented in phase 7.

## Changes

### Domain Layer
- ✅ Creates `Observation` entity with id, absenceId, userId, content, createdAt
- ✅ Defines `ObservationRepositoryPort` with save and findByAbsenceId methods

### Application Layer
- ✅ Creates `CreateObservationCommand` and handler with validation:
  - Verifies absence exists (NotFoundException)
  - Verifies user is creator (ForbiddenException)
  - Uses ClockService for timestamp and generateId for ID
- ✅ Creates `ListObservationsQuery` and handler with validation:
  - Verifies absence exists (NotFoundException)
  - Verifies user is creator (ForbiddenException)
  - Returns observations ordered by createdAt ascending
- ✅ Defines `CreateObservationDto` with content validation
- ✅ Defines `ObservationResponseDto` interface

### Infrastructure Layer
- ✅ Creates `ObservationMapper` (Prisma ↔ domain ↔ DTO)
- ✅ Implements `ObservationPrismaRepository` with Prisma client
- ✅ Creates `ObservationsController` with authenticated endpoints:
  - POST /absences/:absenceId/observations
  - GET /absences/:absenceId/observations

### Module
- ✅ Creates `ObservationsModule` with all providers registered
- ✅ Registers `ObservationsModule` in `AppModule`

### Tests
- ✅ Unit tests for `CreateObservationHandler` (6 test cases)
- ✅ Unit tests for `ListObservationsHandler` (6 test cases)
- ✅ All tests pass (21 test suites, 104 tests)
- ✅ TypeScript compilation passes
- ✅ ESLint passes with 0 warnings

## Technical Notes

**RF-36 Partial Implementation:** The requirement states that validators should also be able to add/view observations. However, since validator assignment hasn't been implemented yet (phase 7), this PR only implements the creator check. A TODO comment has been added to both handlers indicating where the validator check should be added.

**Architecture:** Follows hexagonal architecture with CQRS pattern, repository port/adapter pattern, and proper separation of concerns across domain, application, and infrastructure layers.

## Related Issues

Closes #87
Closes #88  
Closes #89