### PR TITLE
feat(observations): Add attachment list UI with lazy loading and download links

### DIFF
--- a/apps/web/src/components/absences/AttachmentsList.test.tsx
+++ b/apps/web/src/components/absences/AttachmentsList.test.tsx
@@ -1,0 +1,214 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import type { Attachment } from '@repo/types';
+import { AttachmentsList } from './AttachmentsList';
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const mockAttachments: Attachment[] = [
+  {
+    id: '01900000-0000-7000-8000-000000000001',
+    observationId: '01900000-0000-7000-8000-000000000100',
+    filename: 'documento.pdf',
+    mimeType: 'application/pdf',
+    sizeBytes: 1024 * 500, // 500 KB
+    createdAt: '2026-03-01T10:00:00.000Z',
+  },
+  {
+    id: '01900000-0000-7000-8000-000000000002',
+    observationId: '01900000-0000-7000-8000-000000000100',
+    filename: 'imagen.jpg',
+    mimeType: 'image/jpeg',
+    sizeBytes: 1024 * 1024 * 2.5, // 2.5 MB
+    createdAt: '2026-03-02T11:30:00.000Z',
+  },
+];
+
+function renderComponent(observationId = '01900000-0000-7000-8000-000000000100') {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AttachmentsList observationId={observationId} />
+    </QueryClientProvider>
+  );
+}
+
+describe('AttachmentsList', () => {
+  it('muestra estado de carga inicialmente', () => {
+    server.use(
+      http.get('*/observations/:observationId/attachments', async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        return HttpResponse.json([]);
+      })
+    );
+
+    renderComponent();
+
+    expect(screen.getByText('Cargando adjuntos…')).toBeInTheDocument();
+  });
+
+  it('no renderiza nada cuando no hay adjuntos', async () => {
+    server.use(http.get('*/observations/:observationId/attachments', () => HttpResponse.json([])));
+
+    const { container } = renderComponent();
+
+    await waitFor(() => {
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  it('muestra lista de adjuntos existentes', async () => {
+    server.use(
+      http.get('*/observations/:observationId/attachments', () =>
+        HttpResponse.json(mockAttachments)
+      )
+    );
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('documento.pdf')).toBeInTheDocument();
+      expect(screen.getByText('imagen.jpg')).toBeInTheDocument();
+    });
+  });
+
+  it('muestra el conteo de adjuntos', async () => {
+    server.use(
+      http.get('*/observations/:observationId/attachments', () =>
+        HttpResponse.json(mockAttachments)
+      )
+    );
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('Adjuntos (2)')).toBeInTheDocument();
+    });
+  });
+
+  it('formatea correctamente el tamaño de archivos en KB', async () => {
+    server.use(
+      http.get('*/observations/:observationId/attachments', () =>
+        HttpResponse.json(mockAttachments)
+      )
+    );
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('500.0 KB')).toBeInTheDocument();
+    });
+  });
+
+  it('formatea correctamente el tamaño de archivos en MB', async () => {
+    server.use(
+      http.get('*/observations/:observationId/attachments', () =>
+        HttpResponse.json(mockAttachments)
+      )
+    );
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('2.5 MB')).toBeInTheDocument();
+    });
+  });
+
+  it('muestra icono de archivo para PDFs', async () => {
+    server.use(
+      http.get('*/observations/:observationId/attachments', () =>
+        HttpResponse.json([mockAttachments[0]])
+      )
+    );
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('documento.pdf')).toBeInTheDocument();
+      // Verify FileText icon is rendered (lucide-file-text class)
+      const container = screen.getByText('documento.pdf').closest('.space-y-2');
+      expect(container?.querySelector('.lucide-file-text')).toBeInTheDocument();
+    });
+  });
+
+  it('muestra vista previa para imágenes con loading lazy', async () => {
+    server.use(
+      http.get('*/observations/:observationId/attachments', () =>
+        HttpResponse.json([mockAttachments[1]])
+      )
+    );
+
+    renderComponent();
+
+    await waitFor(() => {
+      const images = screen.getAllByAltText('imagen.jpg');
+      expect(images.length).toBeGreaterThan(0);
+      for (const img of images) {
+        expect(img).toHaveAttribute('loading', 'lazy');
+      }
+    });
+  });
+
+  it('incluye enlace de descarga para cada adjunto', async () => {
+    server.use(
+      http.get('*/observations/:observationId/attachments', () =>
+        HttpResponse.json(mockAttachments)
+      )
+    );
+
+    renderComponent();
+
+    await waitFor(() => {
+      const downloadLinks = screen.getAllByRole('link');
+      expect(downloadLinks).toHaveLength(2);
+      for (const link of downloadLinks) {
+        expect(link).toHaveAttribute('href');
+        expect(link.getAttribute('href')).toContain('/download');
+      }
+    });
+  });
+
+  it('incluye aria-label en botones de descarga', async () => {
+    server.use(
+      http.get('*/observations/:observationId/attachments', () =>
+        HttpResponse.json([mockAttachments[0]])
+      )
+    );
+
+    renderComponent();
+
+    await waitFor(() => {
+      const downloadButton = screen.getByLabelText('Descargar documento.pdf');
+      expect(downloadButton).toBeInTheDocument();
+    });
+  });
+
+  it('muestra mensaje de error cuando falla la carga', async () => {
+    server.use(
+      http.get('*/observations/:observationId/attachments', () =>
+        HttpResponse.json({ message: 'Error de servidor' }, { status: 500 })
+      )
+    );
+
+    renderComponent();
+
+    await waitFor(() => {
+      const alert = screen.getByRole('alert');
+      expect(alert).toHaveTextContent('Error al cargar los adjuntos');
+    });
+  });
+});

--- a/apps/web/src/components/absences/AttachmentsList.tsx
+++ b/apps/web/src/components/absences/AttachmentsList.tsx
@@ -1,0 +1,144 @@
+import { Download, FileText } from 'lucide-react';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useAttachments } from '../../hooks/use-attachments';
+import { getAttachmentDownloadUrl } from '../../lib/api-client';
+
+interface AttachmentsListProps {
+  observationId: string;
+}
+
+/**
+ * Formats file size in bytes to human-readable format.
+ *
+ * @param {number} bytes - File size in bytes
+ * @returns {string} Formatted file size (e.g., "1.5 MB")
+ */
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+/**
+ * Determines if a MIME type is an image.
+ *
+ * @param {string} mimeType - MIME type to check
+ * @returns {boolean} True if the MIME type is an image
+ */
+function isImageMimeType(mimeType: string): boolean {
+  return mimeType.startsWith('image/');
+}
+
+/**
+ * Component that displays a list of attachments for an observation.
+ * Supports image preview with lazy loading and file download.
+ */
+export function AttachmentsList({ observationId }: AttachmentsListProps) {
+  const { data: attachments, isLoading, error } = useAttachments(observationId);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        <h3 className="text-sm font-medium">Adjuntos</h3>
+        <p className="text-xs text-muted-foreground">Cargando adjuntos…</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-2">
+        <h3 className="text-sm font-medium">Adjuntos</h3>
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+        >
+          Error al cargar los adjuntos.
+        </div>
+      </div>
+    );
+  }
+
+  if (!attachments || attachments.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-medium">Adjuntos ({attachments.length})</h3>
+      <div className="space-y-2">
+        {attachments.map((attachment) => {
+          const downloadUrl = getAttachmentDownloadUrl(attachment.id);
+          const isImage = isImageMimeType(attachment.mimeType);
+          const createdAt = new Date(attachment.createdAt);
+
+          return (
+            <Card key={attachment.id} className="p-3">
+              <div className="flex items-start gap-3">
+                {/* Icon or image preview */}
+                <div className="flex-shrink-0">
+                  {isImage ? (
+                    <div className="h-12 w-12 overflow-hidden rounded border">
+                      <img
+                        src={downloadUrl}
+                        alt={attachment.filename}
+                        loading="lazy"
+                        className="h-full w-full object-cover"
+                      />
+                    </div>
+                  ) : (
+                    <div className="flex h-12 w-12 items-center justify-center rounded border bg-muted">
+                      <FileText className="h-6 w-6 text-muted-foreground" />
+                    </div>
+                  )}
+                </div>
+
+                {/* File info */}
+                <div className="min-w-0 flex-1 space-y-1">
+                  <p className="truncate text-sm font-medium">{attachment.filename}</p>
+                  <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                    <span>{formatFileSize(attachment.sizeBytes)}</span>
+                    <span>•</span>
+                    <time dateTime={attachment.createdAt}>
+                      {format(createdAt, "d 'de' MMM 'de' yyyy", { locale: es })}
+                    </time>
+                  </div>
+                </div>
+
+                {/* Download button */}
+                <div className="flex-shrink-0">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    asChild
+                    aria-label={`Descargar ${attachment.filename}`}
+                  >
+                    <a href={downloadUrl} download={attachment.filename}>
+                      <Download className="h-4 w-4" />
+                    </a>
+                  </Button>
+                </div>
+              </div>
+
+              {/* Full image preview for images */}
+              {isImage && (
+                <div className="mt-3">
+                  <img
+                    src={downloadUrl}
+                    alt={attachment.filename}
+                    loading="lazy"
+                    className="max-h-64 w-full rounded border object-contain"
+                  />
+                </div>
+              )}
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-attachments.ts
+++ b/apps/web/src/hooks/use-attachments.ts
@@ -1,0 +1,37 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import type { Attachment } from '@repo/types';
+
+import { listAttachments, uploadAttachment } from '../lib/api-client';
+import { attachmentsKeys } from '../lib/query-keys/attachments.keys';
+
+/**
+ * Hook to fetch attachments for a given observation.
+ *
+ * @param {string} observationId - The observation ID
+ * @returns Query result with attachments array
+ */
+export function useAttachments(observationId: string) {
+  return useQuery<Attachment[]>({
+    queryKey: attachmentsKeys.list(observationId),
+    queryFn: () => listAttachments(observationId),
+  });
+}
+
+/**
+ * Hook to upload an attachment to an observation.
+ *
+ * @param {string} observationId - The observation ID
+ * @returns Mutation object with upload function
+ */
+export function useUploadAttachment(observationId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (file: File) => uploadAttachment(observationId, file),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: attachmentsKeys.list(observationId),
+      });
+    },
+  });
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,5 +1,5 @@
 import axios, { isAxiosError } from 'axios';
-import type { User, AbsenceType, Absence, Observation } from '@repo/types';
+import type { User, AbsenceType, Absence, Observation, Attachment } from '@repo/types';
 import { ValidationDecision } from '@repo/types';
 
 import { useAuthStore } from '../store/auth.store';
@@ -169,4 +169,29 @@ export async function createObservation(
     payload
   );
   return response.data;
+}
+
+export async function listAttachments(observationId: string): Promise<Attachment[]> {
+  const response = await apiClient.get<Attachment[]>(`/observations/${observationId}/attachments`);
+  return response.data;
+}
+
+export async function uploadAttachment(observationId: string, file: File): Promise<{ id: string }> {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const response = await apiClient.post<{ id: string }>(
+    `/observations/${observationId}/attachments`,
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    }
+  );
+  return response.data;
+}
+
+export function getAttachmentDownloadUrl(attachmentId: string): string {
+  return `${apiClient.defaults.baseURL}/observations/attachments/${attachmentId}/download`;
 }

--- a/apps/web/src/lib/query-keys/attachments.keys.ts
+++ b/apps/web/src/lib/query-keys/attachments.keys.ts
@@ -1,0 +1,10 @@
+/**
+ * Query key factory for attachments.
+ *
+ * Follows the hierarchical structure recommended in TanStack Query docs.
+ */
+export const attachmentsKeys = {
+  all: ['attachments'] as const,
+  lists: () => [...attachmentsKeys.all, 'list'] as const,
+  list: (observationId: string) => [...attachmentsKeys.lists(), observationId] as const,
+};

--- a/packages/types/src/entities.ts
+++ b/packages/types/src/entities.ts
@@ -1,9 +1,4 @@
-import type {
-  AbsenceStatus,
-  AbsenceUnit,
-  UserRole,
-  ValidationDecision,
-} from './enums';
+import type { AbsenceStatus, AbsenceUnit, UserRole, ValidationDecision } from './enums';
 
 export interface User {
   id: string;
@@ -74,5 +69,14 @@ export interface Notification {
   type: string;
   message: string;
   read: boolean;
+  createdAt: string;
+}
+
+export interface Attachment {
+  id: string;
+  observationId: string;
+  filename: string;
+  mimeType: string;
+  sizeBytes: number;
   createdAt: string;
 }


### PR DESCRIPTION
## Summary

Implements complete frontend functionality for viewing and downloading observation attachments, with:
- AttachmentsList component with image previews and file icons
- Lazy loading for images (loading=lazy attribute)
- Download links with proper accessibility
- React Query hooks for data fetching
- 11 RTL tests with MSW mocking

## Issues Closed

Closes #97
Closes #98

## Requirements Implemented

- **RF-59**: View attachments on observations
- **RF-63**: Download attachments with proper access control

## Features

### AttachmentsList Component
- Displays list of attachments for a given observation
- Shows file icon for PDFs and thumbnails for images
- Full image preview for image files with lazy loading
- Download button with accessibility labels
- File size formatting (KB/MB)
- Date formatting in Spanish locale
- Responsive layout with Tailwind CSS

### React Query Integration
- `useAttachments` hook for fetching attachment list
- `useUploadAttachment` hook for future upload functionality
- Query key factory for proper cache invalidation
- Error handling and loading states

### API Client Functions
- `listAttachments(observationId)` - Fetch attachments for an observation
- `uploadAttachment(observationId, file)` - Upload a file to an observation
- `getAttachmentDownloadUrl(attachmentId)` - Generate download URL

### Accessibility
- Semantic HTML with proper ARIA labels
- `loading=lazy` attribute for images per issue requirements
- Descriptive alt text for images
- Keyboard-navigable download links

## Testing

- ✅ **11 RTL tests passing**:
  - Loading state display
  - Empty state (renders nothing)
  - Attachment list rendering
  - File size formatting (KB/MB)
  - File icon for non-images
  - Image preview with lazy loading
  - Download links with correct URLs
  - ARIA labels on buttons
  - Error state display
  
- ✅ **Lint passing**: 0 errors
- ✅ **TypeCheck passing**: 0 errors
- ⚠️ **1 pre-existing test failure** in `use-session.test.tsx` (not related to this PR)

## Technical Details

- Uses `date-fns` for date formatting (already installed as dependency)
- `lucide-react` icons for FileText and Download
- shadcn/ui Card and Button components
- MSW handlers in tests for API mocking
- Follows established patterns from ObservationsList component

## Screenshots

(Component displays file list with thumbnails for images and icons for PDFs, with download buttons for each file)

## Notes

- Upload functionality is implemented in the hook but UI for uploading will be added in future issues
- Component integrates seamlessly with existing ObservationsList component
- All attachment types (JPEG, PNG, PDF) are properly handled
- Ready for integration into absence detail views