### PR TITLE
feat(notifications): Adds frontend notifications UI with polling and mark as read

### DIFF
--- a/apps/web/src/components/notifications/NotificationsList.test.tsx
+++ b/apps/web/src/components/notifications/NotificationsList.test.tsx
@@ -1,0 +1,185 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import type { Notification } from '@repo/types';
+import { NotificationsList } from './NotificationsList';
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const mockNotifications: Notification[] = [
+  {
+    id: '01900000-0000-7000-8000-000000000001',
+    userId: '01900000-0000-7000-8000-000000000010',
+    absenceId: '01900000-0000-7000-8000-000000000020',
+    type: 'validator_assignment',
+    message: 'Nueva ausencia de Juan Pérez asignada para validación',
+    read: false,
+    createdAt: '2026-03-03T10:00:00.000Z',
+  },
+  {
+    id: '01900000-0000-7000-8000-000000000002',
+    userId: '01900000-0000-7000-8000-000000000010',
+    absenceId: '01900000-0000-7000-8000-000000000021',
+    type: 'status_change',
+    message: 'Tu ausencia ha cambiado a: Aprobada',
+    read: true,
+    createdAt: '2026-03-02T14:30:00.000Z',
+  },
+];
+
+function renderComponent() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <NotificationsList />
+    </QueryClientProvider>
+  );
+}
+
+describe('NotificationsList', () => {
+  it('muestra estado de carga inicialmente', () => {
+    server.use(
+      http.get('*/notifications', async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        return HttpResponse.json([]);
+      })
+    );
+
+    renderComponent();
+
+    expect(screen.getByText('Cargando notificaciones…')).toBeInTheDocument();
+  });
+
+  it('muestra mensaje cuando no hay notificaciones', async () => {
+    server.use(http.get('*/notifications', () => HttpResponse.json([])));
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('No tienes notificaciones nuevas.')).toBeInTheDocument();
+    });
+  });
+
+  it('muestra lista de notificaciones', async () => {
+    server.use(http.get('*/notifications', () => HttpResponse.json(mockNotifications)));
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Nueva ausencia de Juan Pérez asignada para validación')
+      ).toBeInTheDocument();
+      expect(screen.getByText('Tu ausencia ha cambiado a: Aprobada')).toBeInTheDocument();
+    });
+  });
+
+  it('muestra el conteo de notificaciones no leídas', async () => {
+    server.use(http.get('*/notifications', () => HttpResponse.json(mockNotifications)));
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('1')).toBeInTheDocument();
+    });
+  });
+
+  it('diferencia visualmente entre notificaciones leídas y no leídas', async () => {
+    server.use(http.get('*/notifications', () => HttpResponse.json(mockNotifications)));
+
+    renderComponent();
+
+    await waitFor(() => {
+      const unreadNotification = screen
+        .getByText('Nueva ausencia de Juan Pérez asignada para validación')
+        .closest(String.raw`div.border-primary\/20`);
+      const readNotification = screen
+        .getByText('Tu ausencia ha cambiado a: Aprobada')
+        .closest(String.raw`div.bg-muted\/30`);
+
+      expect(unreadNotification).toBeInTheDocument();
+      expect(readNotification).toBeInTheDocument();
+    });
+  });
+
+  it('muestra botón de marcar como leída solo en notificaciones no leídas', async () => {
+    server.use(http.get('*/notifications', () => HttpResponse.json(mockNotifications)));
+
+    renderComponent();
+
+    await waitFor(() => {
+      const buttons = screen.getAllByRole('button', { name: 'Marcar como leída' });
+      expect(buttons).toHaveLength(1);
+    });
+  });
+
+  it('marca notificación como leída al hacer clic en el botón', async () => {
+    const user = userEvent.setup();
+
+    let notificationsData = [...mockNotifications];
+
+    server.use(
+      http.get('*/notifications', () => HttpResponse.json(notificationsData)),
+      http.patch('*/notifications/:id/read', ({ params }) => {
+        const { id } = params;
+        // Update the notification to read in the mock data
+        notificationsData = notificationsData.map((notification) =>
+          notification.id === id ? { ...notification, read: true } : notification
+        );
+        return HttpResponse.json({ success: true });
+      })
+    );
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Nueva ausencia de Juan Pérez asignada para validación')
+      ).toBeInTheDocument();
+    });
+
+    const markAsReadButton = screen.getByRole('button', { name: 'Marcar como leída' });
+    await user.click(markAsReadButton);
+
+    // El botón debería desaparecer después de marcar como leída
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Marcar como leída' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('muestra error cuando falla la carga de notificaciones', async () => {
+    server.use(http.get('*/notifications', () => HttpResponse.error()));
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Error al cargar las notificaciones. Por favor, inténtalo de nuevo.')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('muestra tiempo relativo de creación', async () => {
+    server.use(http.get('*/notifications', () => HttpResponse.json(mockNotifications)));
+
+    renderComponent();
+
+    await waitFor(() => {
+      const timeElements = screen.getAllByText(/hace/i);
+      expect(timeElements.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/apps/web/src/components/notifications/NotificationsList.tsx
+++ b/apps/web/src/components/notifications/NotificationsList.tsx
@@ -1,0 +1,125 @@
+import { Bell, BellDot, Check } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+import { es } from 'date-fns/locale';
+
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useNotifications, useMarkNotificationAsRead } from '../../hooks/use-notifications';
+
+/**
+ * Component that displays a list of notifications with read/unread states.
+ * Includes polling functionality to check for new notifications periodically.
+ * Allows users to mark individual notifications as read.
+ */
+export function NotificationsList() {
+  const { data: notifications, isLoading, error } = useNotifications();
+  const markAsRead = useMarkNotificationAsRead();
+
+  const handleMarkAsRead = (notificationId: string) => {
+    markAsRead.mutate(notificationId);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Bell className="h-5 w-5" />
+          <h2 className="text-lg font-semibold">Notificaciones</h2>
+        </div>
+        <p className="text-sm text-muted-foreground">Cargando notificaciones…</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Bell className="h-5 w-5" />
+          <h2 className="text-lg font-semibold">Notificaciones</h2>
+        </div>
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+        >
+          Error al cargar las notificaciones. Por favor, inténtalo de nuevo.
+        </div>
+      </div>
+    );
+  }
+
+  if (!notifications || notifications.length === 0) {
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Bell className="h-5 w-5" />
+          <h2 className="text-lg font-semibold">Notificaciones</h2>
+        </div>
+        <Card className="p-6">
+          <p className="text-center text-sm text-muted-foreground">
+            No tienes notificaciones nuevas.
+          </p>
+        </Card>
+      </div>
+    );
+  }
+
+  const unreadCount = notifications.filter((n) => !n.read).length;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Bell className="h-5 w-5" />
+        <h2 className="text-lg font-semibold">Notificaciones</h2>
+        {unreadCount > 0 && (
+          <span className="rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground">
+            {unreadCount}
+          </span>
+        )}
+      </div>
+
+      <div className="space-y-2">
+        {notifications.map((notification) => {
+          const createdAt = new Date(notification.createdAt);
+          const timeAgo = formatDistanceToNow(createdAt, { locale: es, addSuffix: true });
+
+          return (
+            <Card
+              key={notification.id}
+              className={notification.read ? 'bg-muted/30' : 'border-primary/20 bg-primary/5'}
+            >
+              <div className="flex items-start gap-3 p-4">
+                <div className="mt-0.5">
+                  {notification.read ? (
+                    <Bell className="h-4 w-4 text-muted-foreground" />
+                  ) : (
+                    <BellDot className="h-4 w-4 text-primary" />
+                  )}
+                </div>
+
+                <div className="flex-1 space-y-1">
+                  <p className={`text-sm ${notification.read ? 'text-muted-foreground' : ''}`}>
+                    {notification.message}
+                  </p>
+                  <p className="text-xs text-muted-foreground">{timeAgo}</p>
+                </div>
+
+                {!notification.read && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => handleMarkAsRead(notification.id)}
+                    disabled={markAsRead.isPending}
+                    aria-label="Marcar como leída"
+                  >
+                    <Check className="h-4 w-4" />
+                  </Button>
+                )}
+              </div>
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-notifications.ts
+++ b/apps/web/src/hooks/use-notifications.ts
@@ -1,0 +1,65 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { Notification } from '@repo/types';
+
+import { listNotifications, markNotificationAsRead } from '../lib/api-client';
+import { notificationsKeys } from '../lib/query-keys/notifications.keys';
+
+/**
+ * Hook to list notifications with polling.
+ *
+ * Polls every 30 seconds to check for new notifications.
+ * Data is considered stale after 25 seconds to trigger background refetch.
+ */
+export function useNotifications() {
+  return useQuery<Notification[], Error>({
+    queryKey: notificationsKeys.list(),
+    queryFn: listNotifications,
+    staleTime: 25_000, // 25 seconds
+    refetchInterval: 30_000, // 30 seconds
+    refetchIntervalInBackground: false,
+  });
+}
+
+/**
+ * Hook to mark a notification as read.
+ *
+ * Optimistically updates the UI and refetches notifications on success.
+ */
+export function useMarkNotificationAsRead() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (notificationId: string) => markNotificationAsRead(notificationId),
+    onMutate: async (notificationId: string) => {
+      // Cancel outgoing refetches
+      await queryClient.cancelQueries({ queryKey: notificationsKeys.list() });
+
+      // Snapshot the previous value
+      const previousNotifications = queryClient.getQueryData<Notification[]>(
+        notificationsKeys.list()
+      );
+
+      // Optimistically update to mark as read
+      if (previousNotifications) {
+        queryClient.setQueryData<Notification[]>(
+          notificationsKeys.list(),
+          previousNotifications.map((notification) =>
+            notification.id === notificationId ? { ...notification, read: true } : notification
+          )
+        );
+      }
+
+      return { previousNotifications };
+    },
+    onError: (_error, _notificationId, context) => {
+      // Rollback to previous value on error
+      if (context?.previousNotifications) {
+        queryClient.setQueryData(notificationsKeys.list(), context.previousNotifications);
+      }
+    },
+    onSettled: () => {
+      // Always refetch after error or success
+      void queryClient.invalidateQueries({ queryKey: notificationsKeys.list() });
+    },
+  });
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -1,5 +1,12 @@
 import axios, { isAxiosError } from 'axios';
-import type { User, AbsenceType, Absence, Observation, Attachment } from '@repo/types';
+import type {
+  User,
+  AbsenceType,
+  Absence,
+  Observation,
+  Attachment,
+  Notification,
+} from '@repo/types';
 import { ValidationDecision } from '@repo/types';
 
 import { useAuthStore } from '../store/auth.store';
@@ -194,4 +201,13 @@ export async function uploadAttachment(observationId: string, file: File): Promi
 
 export function getAttachmentDownloadUrl(attachmentId: string): string {
   return `${apiClient.defaults.baseURL}/observations/attachments/${attachmentId}/download`;
+}
+
+export async function listNotifications(): Promise<Notification[]> {
+  const response = await apiClient.get<Notification[]>('/notifications');
+  return response.data;
+}
+
+export async function markNotificationAsRead(notificationId: string): Promise<void> {
+  await apiClient.patch(`/notifications/${notificationId}/read`);
 }

--- a/apps/web/src/lib/query-keys/notifications.keys.ts
+++ b/apps/web/src/lib/query-keys/notifications.keys.ts
@@ -1,0 +1,8 @@
+/**
+ * Query keys for notifications.
+ */
+export const notificationsKeys = {
+  all: ['notifications'] as const,
+  lists: () => [...notificationsKeys.all, 'list'] as const,
+  list: () => [...notificationsKeys.lists()] as const,
+};


### PR DESCRIPTION
## Summary

Implements frontend UI for notifications with polling functionality (issues #102, #103):

- **NotificationsList component**: Displays list of notifications with read/unread visual distinction, unread count badge, and mark-as-read buttons
- **TanStack Query polling**: Configured with 30-second refetch interval and 25-second stale time
- **Custom hooks**: `useNotifications()` for fetching with polling, `useMarkNotificationAsRead()` with optimistic updates
- **RTL tests**: 9 comprehensive tests with MSW handlers for API mocking
- **API client methods**: `listNotifications()` and `markNotificationAsRead(notificationId)`

All tests pass, lint and typecheck clean.

Refs: #102, #103