### PR TITLE
feat(absences): Adds calendar endpoint with user and team absences

### DIFF
--- a/apps/api/src/modules/absences/absences.module.ts
+++ b/apps/api/src/modules/absences/absences.module.ts
@@ -14,11 +14,15 @@ import { AbsenceStateMachineService } from './domain/services/absence-state-mach
 import { CreateAbsenceHandler } from './application/commands/create-absence.handler';
 import { ValidateAbsenceHandler } from './application/commands/validate-absence.handler';
 import { CancelAbsenceHandler } from './application/commands/cancel-absence.handler';
+import { GetCalendarAbsencesHandler } from './application/queries/get-calendar-absences.handler';
+import { AbsencesController } from './infrastructure/absences.controller';
 
 const commandHandlers = [CreateAbsenceHandler, ValidateAbsenceHandler, CancelAbsenceHandler];
+const queryHandlers = [GetCalendarAbsencesHandler];
 
 @Module({
   imports: [CqrsModule, PrismaModule, AbsenceTypesModule],
+  controllers: [AbsencesController],
   providers: [
     ClockService,
     // Repository
@@ -35,6 +39,8 @@ const commandHandlers = [CreateAbsenceHandler, ValidateAbsenceHandler, CancelAbs
     AbsenceStateMachineService,
     // Command handlers
     ...commandHandlers,
+    // Query handlers
+    ...queryHandlers,
   ],
   exports: [ABSENCE_REPOSITORY_PORT, DurationCalculatorService, AnnualLimitValidatorService],
 })

--- a/apps/api/src/modules/absences/application/commands/cancel-absence.handler.spec.ts
+++ b/apps/api/src/modules/absences/application/commands/cancel-absence.handler.spec.ts
@@ -38,6 +38,7 @@ describe('CancelAbsenceHandler', () => {
       getValidationHistory: jest.fn(),
       getAssignedValidators: jest.fn(),
       assignValidators: jest.fn(),
+      findCalendarAbsences: jest.fn(),
     };
 
     mockClockService = {

--- a/apps/api/src/modules/absences/application/commands/create-absence.handler.spec.ts
+++ b/apps/api/src/modules/absences/application/commands/create-absence.handler.spec.ts
@@ -38,6 +38,7 @@ describe('CreateAbsenceHandler', () => {
       getValidationHistory: jest.fn(),
       getAssignedValidators: jest.fn(),
       assignValidators: jest.fn(),
+      findCalendarAbsences: jest.fn(),
     };
 
     mockAbsenceTypeRepository = {

--- a/apps/api/src/modules/absences/application/commands/validate-absence.handler.spec.ts
+++ b/apps/api/src/modules/absences/application/commands/validate-absence.handler.spec.ts
@@ -37,6 +37,7 @@ describe('ValidateAbsenceHandler', () => {
       getValidationHistory: jest.fn(),
       getAssignedValidators: jest.fn(),
       assignValidators: jest.fn(),
+      findCalendarAbsences: jest.fn(),
     };
 
     mockClockService = {

--- a/apps/api/src/modules/absences/application/dtos/calendar-absence-response.dto.ts
+++ b/apps/api/src/modules/absences/application/dtos/calendar-absence-response.dto.ts
@@ -1,0 +1,26 @@
+import { AbsenceStatus } from '@repo/types';
+
+/**
+ * DTO for calendar absence response.
+ *
+ * Includes additional information for calendar display:
+ * - isOwn: Whether this absence belongs to the requesting user
+ * - teamColor: Color for team absences (null for own absences)
+ * - userName: Name of the user who created the absence
+ * - absenceTypeName: Name of the absence type
+ */
+export class CalendarAbsenceResponseDto {
+  id!: string;
+  userId!: string;
+  userName!: string;
+  absenceTypeId!: string;
+  absenceTypeName!: string;
+  startAt!: string;
+  endAt!: string;
+  duration!: number;
+  status!: AbsenceStatus | null;
+  isOwn!: boolean;
+  teamColor!: string | null;
+  createdAt!: string;
+  updatedAt!: string;
+}

--- a/apps/api/src/modules/absences/application/queries/get-calendar-absences.handler.spec.ts
+++ b/apps/api/src/modules/absences/application/queries/get-calendar-absences.handler.spec.ts
@@ -1,0 +1,200 @@
+import { AbsenceStatus } from '@repo/types';
+
+import type { AbsenceRepositoryPort } from '../../domain/ports/absence.repository.port';
+import { GetCalendarAbsencesQuery } from './get-calendar-absences.query';
+import { GetCalendarAbsencesHandler } from './get-calendar-absences.handler';
+
+const NOW = new Date('2025-01-01T00:00:00.000Z');
+
+const makeAbsenceRepo = (
+  overrides: Partial<AbsenceRepositoryPort> = {}
+): AbsenceRepositoryPort => ({
+  findById: jest.fn(),
+  save: jest.fn(),
+  update: jest.fn(),
+  createStatusHistory: jest.fn(),
+  calculateConsumedByUserAndTypeInYear: jest.fn(),
+  hasOverlap: jest.fn(),
+  createValidationHistory: jest.fn(),
+  getValidationHistory: jest.fn(),
+  getAssignedValidators: jest.fn(),
+  assignValidators: jest.fn(),
+  findCalendarAbsences: jest.fn().mockResolvedValue([]),
+  ...overrides,
+});
+
+describe('GetCalendarAbsencesHandler', () => {
+  it('successfully returns calendar absences for a user', async () => {
+    const mockAbsences = [
+      {
+        id: 'absence-1',
+        userId: 'user-1',
+        userName: 'John Doe',
+        absenceTypeId: 'type-1',
+        absenceTypeName: 'Vacation',
+        startAt: new Date('2025-02-01T00:00:00.000Z'),
+        endAt: new Date('2025-02-05T23:59:59.999Z'),
+        duration: 5,
+        status: AbsenceStatus.ACCEPTED,
+        teamColor: null,
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+      {
+        id: 'absence-2',
+        userId: 'user-2',
+        userName: 'Jane Smith',
+        absenceTypeId: 'type-1',
+        absenceTypeName: 'Vacation',
+        startAt: new Date('2025-02-10T00:00:00.000Z'),
+        endAt: new Date('2025-02-12T23:59:59.999Z'),
+        duration: 3,
+        status: AbsenceStatus.ACCEPTED,
+        teamColor: '#FF0000',
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ];
+
+    const absenceRepo = makeAbsenceRepo({
+      findCalendarAbsences: jest.fn().mockResolvedValue(mockAbsences),
+    });
+
+    const handler = new GetCalendarAbsencesHandler(absenceRepo);
+    const query = new GetCalendarAbsencesQuery('user-1');
+
+    const result = await handler.execute(query);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('absence-1');
+    expect(result[0].userId).toBe('user-1');
+    expect(result[0].userName).toBe('John Doe');
+    expect(result[0].absenceTypeName).toBe('Vacation');
+    expect(result[0].isOwn).toBe(true);
+    expect(result[0].teamColor).toBeNull();
+    expect(result[0].startAt).toBe('2025-02-01T00:00:00.000Z');
+    expect(result[0].endAt).toBe('2025-02-05T23:59:59.999Z');
+
+    expect(result[1].id).toBe('absence-2');
+    expect(result[1].userId).toBe('user-2');
+    expect(result[1].userName).toBe('Jane Smith');
+    expect(result[1].isOwn).toBe(false);
+    expect(result[1].teamColor).toBe('#FF0000');
+
+    expect(absenceRepo.findCalendarAbsences).toHaveBeenCalledWith('user-1');
+  });
+
+  it('returns empty array when user has no absences', async () => {
+    const absenceRepo = makeAbsenceRepo({
+      findCalendarAbsences: jest.fn().mockResolvedValue([]),
+    });
+
+    const handler = new GetCalendarAbsencesHandler(absenceRepo);
+    const query = new GetCalendarAbsencesQuery('user-1');
+
+    const result = await handler.execute(query);
+
+    expect(result).toEqual([]);
+    expect(absenceRepo.findCalendarAbsences).toHaveBeenCalledWith('user-1');
+  });
+
+  it('correctly marks own absences with isOwn=true and teamColor=null', async () => {
+    const mockAbsences = [
+      {
+        id: 'absence-1',
+        userId: 'user-1',
+        userName: 'John Doe',
+        absenceTypeId: 'type-1',
+        absenceTypeName: 'Vacation',
+        startAt: new Date('2025-02-01T00:00:00.000Z'),
+        endAt: new Date('2025-02-05T23:59:59.999Z'),
+        duration: 5,
+        status: AbsenceStatus.WAITING_VALIDATION,
+        teamColor: null,
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ];
+
+    const absenceRepo = makeAbsenceRepo({
+      findCalendarAbsences: jest.fn().mockResolvedValue(mockAbsences),
+    });
+
+    const handler = new GetCalendarAbsencesHandler(absenceRepo);
+    const query = new GetCalendarAbsencesQuery('user-1');
+
+    const result = await handler.execute(query);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].isOwn).toBe(true);
+    expect(result[0].teamColor).toBeNull();
+    expect(result[0].userId).toBe('user-1');
+  });
+
+  it('correctly marks team absences with isOwn=false and includes teamColor', async () => {
+    const mockAbsences = [
+      {
+        id: 'absence-2',
+        userId: 'user-2',
+        userName: 'Jane Smith',
+        absenceTypeId: 'type-1',
+        absenceTypeName: 'Sick Leave',
+        startAt: new Date('2025-02-10T00:00:00.000Z'),
+        endAt: new Date('2025-02-12T23:59:59.999Z'),
+        duration: 3,
+        status: AbsenceStatus.ACCEPTED,
+        teamColor: '#00FF00',
+        createdAt: NOW,
+        updatedAt: NOW,
+      },
+    ];
+
+    const absenceRepo = makeAbsenceRepo({
+      findCalendarAbsences: jest.fn().mockResolvedValue(mockAbsences),
+    });
+
+    const handler = new GetCalendarAbsencesHandler(absenceRepo);
+    const query = new GetCalendarAbsencesQuery('user-1');
+
+    const result = await handler.execute(query);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].isOwn).toBe(false);
+    expect(result[0].teamColor).toBe('#00FF00');
+    expect(result[0].userId).toBe('user-2');
+    expect(result[0].userName).toBe('Jane Smith');
+  });
+
+  it('converts Date objects to ISO strings in response', async () => {
+    const mockAbsences = [
+      {
+        id: 'absence-1',
+        userId: 'user-1',
+        userName: 'John Doe',
+        absenceTypeId: 'type-1',
+        absenceTypeName: 'Vacation',
+        startAt: new Date('2025-02-01T00:00:00.000Z'),
+        endAt: new Date('2025-02-05T23:59:59.999Z'),
+        duration: 5,
+        status: null,
+        teamColor: null,
+        createdAt: new Date('2025-01-15T10:00:00.000Z'),
+        updatedAt: new Date('2025-01-15T10:00:00.000Z'),
+      },
+    ];
+
+    const absenceRepo = makeAbsenceRepo({
+      findCalendarAbsences: jest.fn().mockResolvedValue(mockAbsences),
+    });
+
+    const handler = new GetCalendarAbsencesHandler(absenceRepo);
+    const query = new GetCalendarAbsencesQuery('user-1');
+
+    const result = await handler.execute(query);
+
+    expect(result[0].startAt).toBe('2025-02-01T00:00:00.000Z');
+    expect(result[0].endAt).toBe('2025-02-05T23:59:59.999Z');
+    expect(result[0].createdAt).toBe('2025-01-15T10:00:00.000Z');
+    expect(result[0].updatedAt).toBe('2025-01-15T10:00:00.000Z');
+  });
+});

--- a/apps/api/src/modules/absences/application/queries/get-calendar-absences.handler.ts
+++ b/apps/api/src/modules/absences/application/queries/get-calendar-absences.handler.ts
@@ -1,0 +1,49 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { IQueryHandler, QueryHandler } from '@nestjs/cqrs';
+
+import {
+  ABSENCE_REPOSITORY_PORT,
+  AbsenceRepositoryPort,
+} from '../../domain/ports/absence.repository.port';
+import type { CalendarAbsenceResponseDto } from '../dtos/calendar-absence-response.dto';
+import { GetCalendarAbsencesQuery } from './get-calendar-absences.query';
+
+/**
+ * Query handler for getting calendar absences.
+ *
+ * Implements:
+ * - RF-46: Calendar view showing all user's absences
+ * - RF-69: Show team members' absences
+ * - RF-70: Different colors for own vs team absences
+ */
+@Injectable()
+@QueryHandler(GetCalendarAbsencesQuery)
+export class GetCalendarAbsencesHandler implements IQueryHandler<
+  GetCalendarAbsencesQuery,
+  CalendarAbsenceResponseDto[]
+> {
+  constructor(
+    @Inject(ABSENCE_REPOSITORY_PORT)
+    private readonly absenceRepository: AbsenceRepositoryPort
+  ) {}
+
+  async execute(query: GetCalendarAbsencesQuery): Promise<CalendarAbsenceResponseDto[]> {
+    const absences = await this.absenceRepository.findCalendarAbsences(query.userId);
+
+    return absences.map((absence) => ({
+      id: absence.id,
+      userId: absence.userId,
+      userName: absence.userName,
+      absenceTypeId: absence.absenceTypeId,
+      absenceTypeName: absence.absenceTypeName,
+      startAt: absence.startAt.toISOString(),
+      endAt: absence.endAt.toISOString(),
+      duration: absence.duration,
+      status: absence.status,
+      isOwn: absence.userId === query.userId,
+      teamColor: absence.teamColor,
+      createdAt: absence.createdAt.toISOString(),
+      updatedAt: absence.updatedAt.toISOString(),
+    }));
+  }
+}

--- a/apps/api/src/modules/absences/application/queries/get-calendar-absences.query.ts
+++ b/apps/api/src/modules/absences/application/queries/get-calendar-absences.query.ts
@@ -1,0 +1,13 @@
+/**
+ * Query to get calendar absences for a user.
+ *
+ * Implements RF-46 (calendar view), RF-69 (team absences), and RF-70 (color distinction).
+ *
+ * Returns:
+ * - All absences of the requesting user (regardless of status)
+ * - All absences of team members in shared teams
+ * - Includes team color information for proper frontend rendering
+ */
+export class GetCalendarAbsencesQuery {
+  constructor(public readonly userId: string) {}
+}

--- a/apps/api/src/modules/absences/domain/ports/absence.repository.port.ts
+++ b/apps/api/src/modules/absences/domain/ports/absence.repository.port.ts
@@ -103,6 +103,34 @@ export interface AbsenceRepositoryPort {
    * @param assignedAt - The timestamp of assignment
    */
   assignValidators(absenceId: string, validatorIds: string[], assignedAt: Date): Promise<void>;
+
+  /**
+   * Gets absences for the calendar view (RF-46, RF-69, RF-70).
+   *
+   * Returns:
+   * - All absences of the specified user
+   * - All absences of team members in teams the user belongs to
+   * - Includes user name, absence type name, and team color
+   *
+   * @param userId - The ID of the user requesting the calendar view
+   * @returns Array of calendar absences with additional display information
+   */
+  findCalendarAbsences(userId: string): Promise<
+    Array<{
+      id: string;
+      userId: string;
+      userName: string;
+      absenceTypeId: string;
+      absenceTypeName: string;
+      startAt: Date;
+      endAt: Date;
+      duration: number;
+      status: AbsenceStatus | null;
+      teamColor: string | null;
+      createdAt: Date;
+      updatedAt: Date;
+    }>
+  >;
 }
 
 export const ABSENCE_REPOSITORY_PORT = Symbol('AbsenceRepositoryPort');

--- a/apps/api/src/modules/absences/domain/services/annual-limit-validator.service.spec.ts
+++ b/apps/api/src/modules/absences/domain/services/annual-limit-validator.service.spec.ts
@@ -20,6 +20,7 @@ describe('AnnualLimitValidatorService', () => {
       getValidationHistory: jest.fn(),
       getAssignedValidators: jest.fn(),
       assignValidators: jest.fn(),
+      findCalendarAbsences: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/apps/api/src/modules/absences/domain/services/overlap-validator.service.spec.ts
+++ b/apps/api/src/modules/absences/domain/services/overlap-validator.service.spec.ts
@@ -19,6 +19,7 @@ describe('OverlapValidatorService', () => {
       getValidationHistory: jest.fn(),
       getAssignedValidators: jest.fn(),
       assignValidators: jest.fn(),
+      findCalendarAbsences: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/apps/api/src/modules/absences/infrastructure/absence.prisma.repository.ts
+++ b/apps/api/src/modules/absences/infrastructure/absence.prisma.repository.ts
@@ -196,4 +196,118 @@ export class AbsencePrismaRepository implements AbsenceRepositoryPort {
       })),
     });
   }
+
+  /**
+   * Gets absences for the calendar view (RF-46, RF-69, RF-70).
+   *
+   * Returns:
+   * - All absences of the specified user
+   * - All absences of team members in teams the user belongs to
+   * - Includes user name, absence type name, and team color
+   *
+   * The query is optimized with proper joins to avoid N+1 queries.
+   */
+  async findCalendarAbsences(userId: string): Promise<
+    Array<{
+      id: string;
+      userId: string;
+      userName: string;
+      absenceTypeId: string;
+      absenceTypeName: string;
+      startAt: Date;
+      endAt: Date;
+      duration: number;
+      status: AbsenceStatus | null;
+      teamColor: string | null;
+      createdAt: Date;
+      updatedAt: Date;
+    }>
+  > {
+    // First, get the user's own absences
+    const ownAbsences = await this.prisma.absence.findMany({
+      where: { user_id: userId },
+      include: {
+        user: { select: { name: true } },
+        absence_type: { select: { name: true } },
+      },
+      orderBy: { start_at: 'asc' },
+    });
+
+    // Get team IDs where the user is a member
+    const userTeams = await this.prisma.team_member.findMany({
+      where: { user_id: userId },
+      select: { team_id: true },
+    });
+
+    const teamIds = userTeams.map((tm) => tm.team_id);
+
+    // Get absences of team members (excluding the user's own absences)
+    const teamAbsences = await this.prisma.absence.findMany({
+      where: {
+        user_id: { not: userId },
+        user: {
+          team_memberships: {
+            some: {
+              team_id: { in: teamIds },
+            },
+          },
+        },
+      },
+      include: {
+        user: {
+          select: {
+            name: true,
+            team_memberships: {
+              where: { team_id: { in: teamIds } },
+              include: { team: { select: { color: true } } },
+            },
+          },
+        },
+        absence_type: { select: { name: true } },
+      },
+      orderBy: { start_at: 'asc' },
+    });
+
+    // Map own absences (no team color)
+    const mappedOwnAbsences = ownAbsences.map((absence) => ({
+      id: absence.id,
+      userId: absence.user_id,
+      userName: absence.user.name,
+      absenceTypeId: absence.absence_type_id,
+      absenceTypeName: absence.absence_type.name,
+      startAt: absence.start_at,
+      endAt: absence.end_at,
+      duration: Number(absence.duration),
+      status: absence.status as AbsenceStatus | null,
+      teamColor: null,
+      createdAt: absence.created_at,
+      updatedAt: absence.updated_at,
+    }));
+
+    // Map team absences (with team color)
+    const mappedTeamAbsences = teamAbsences.map((absence) => {
+      // Get the first matching team color (a user might be in multiple teams)
+      const teamColor = absence.user.team_memberships[0]?.team.color ?? null;
+
+      return {
+        id: absence.id,
+        userId: absence.user_id,
+        userName: absence.user.name,
+        absenceTypeId: absence.absence_type_id,
+        absenceTypeName: absence.absence_type.name,
+        startAt: absence.start_at,
+        endAt: absence.end_at,
+        duration: Number(absence.duration),
+        status: absence.status as AbsenceStatus | null,
+        teamColor,
+        createdAt: absence.created_at,
+        updatedAt: absence.updated_at,
+      };
+    });
+
+    // Combine and sort by start date
+    return [...mappedOwnAbsences, ...mappedTeamAbsences].sort((a, b) =>
+      a.startAt < b.startAt ? -1 : 1
+    );
+  }
 }

--- a/apps/api/src/modules/absences/infrastructure/absences.controller.ts
+++ b/apps/api/src/modules/absences/infrastructure/absences.controller.ts
@@ -1,0 +1,42 @@
+import { Controller, Get, Req, UseGuards } from '@nestjs/common';
+import { QueryBus } from '@nestjs/cqrs';
+import type { Request } from 'express';
+
+import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
+import type { CalendarAbsenceResponseDto } from '../application/dtos/calendar-absence-response.dto';
+import { GetCalendarAbsencesQuery } from '../application/queries/get-calendar-absences.query';
+
+/**
+ * Controller for absence endpoints.
+ *
+ * Implements RF-46 (calendar view), RF-69 (team absences), and RF-70 (color distinction).
+ */
+@UseGuards(JwtAuthGuard)
+@Controller('absences')
+export class AbsencesController {
+  constructor(private readonly queryBus: QueryBus) {}
+
+  /**
+   * Gets calendar absences for the authenticated user.
+   *
+   * GET /absences/calendar
+   *
+   * Returns:
+   * - All absences of the requesting user (regardless of status)
+   * - All absences of team members in shared teams
+   * - Includes team color information for proper frontend rendering
+   *
+   * RF-46: Calendar view for standard users and validators
+   * RF-69: Show team members' absences
+   * RF-70: Different colors for own absences vs team absences
+   * RF-71: Team absences are read-only (enforced in frontend)
+   */
+  @Get('calendar')
+  async getCalendarAbsences(@Req() request: Request): Promise<CalendarAbsenceResponseDto[]> {
+    const user = request.user as { userId: string };
+
+    return this.queryBus.execute<GetCalendarAbsencesQuery, CalendarAbsenceResponseDto[]>(
+      new GetCalendarAbsencesQuery(user.userId)
+    );
+  }
+}

--- a/apps/api/src/modules/observations/application/commands/create-observation.handler.spec.ts
+++ b/apps/api/src/modules/observations/application/commands/create-observation.handler.spec.ts
@@ -27,6 +27,11 @@ const makeAbsenceRepo = (
   createStatusHistory: jest.fn(),
   calculateConsumedByUserAndTypeInYear: jest.fn(),
   hasOverlap: jest.fn(),
+  createValidationHistory: jest.fn(),
+  getValidationHistory: jest.fn(),
+  getAssignedValidators: jest.fn(),
+  assignValidators: jest.fn(),
+  findCalendarAbsences: jest.fn(),
   ...overrides,
 });
 

--- a/apps/api/src/modules/observations/application/queries/list-observations.handler.spec.ts
+++ b/apps/api/src/modules/observations/application/queries/list-observations.handler.spec.ts
@@ -28,6 +28,11 @@ const makeAbsenceRepo = (
   createStatusHistory: jest.fn(),
   calculateConsumedByUserAndTypeInYear: jest.fn(),
   hasOverlap: jest.fn(),
+  createValidationHistory: jest.fn(),
+  getValidationHistory: jest.fn(),
+  getAssignedValidators: jest.fn(),
+  assignValidators: jest.fn(),
+  findCalendarAbsences: jest.fn(),
   ...overrides,
 });
 


### PR DESCRIPTION
## Summary

Implements backend calendar endpoint for issue #104 (RF-46, RF-69, RF-70):

**GET /absences/calendar** - Returns calendar absences for the authenticated user:
- **Own absences**: All absences of the requesting user (regardless of status) with isOwn=true and teamColor=null
- **Team absences**: All absences of team members in shared teams with isOwn=false and their team color
- **Optimized query**: Uses proper Prisma joins to avoid N+1 problems
- **Comprehensive data**: Includes user name, absence type name, dates, duration, status

**Implementation details**:
- New query handler: GetCalendarAbsencesHandler
- New DTO: CalendarAbsenceResponseDto with extended fields for calendar display
- Repository method: findCalendarAbsences() in AbsencePrismaRepository
- Controller: AbsencesController with /absences/calendar endpoint
- 5 unit tests covering all scenarios

**Functional requirements**:
- RF-46: Calendar view showing all user absences
- RF-69: Show team members absences in calendar
- RF-70: Different colors for own absences vs team absences
- RF-71: Team absences are read-only (enforced in frontend)

**Note**: Also fixed missing findCalendarAbsences mock in existing test files to maintain type safety.

All calendar endpoint tests pass. Lint passes.

Refs: #104