### PR TITLE
feat(dashboard): Adds dashboard UI with balance, upcoming absences, and pending validations

### DIFF
--- a/apps/web/src/components/dashboard/BalanceCard.tsx
+++ b/apps/web/src/components/dashboard/BalanceCard.tsx
@@ -1,0 +1,50 @@
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
+import type { AbsenceTypeBalance } from '../../lib/api-client';
+
+interface BalanceCardProps {
+  balance: AbsenceTypeBalance;
+}
+
+/**
+ * BalanceCard component displays the balance for a specific absence type.
+ *
+ * Shows:
+ * - Absence type name
+ * - Maximum allowed per year
+ * - Consumed amount
+ * - Remaining amount
+ * - Unit (hours/days)
+ *
+ * Part of RF-55 (Dashboard view).
+ */
+export function BalanceCard({ balance }: BalanceCardProps) {
+  const unitLabel = balance.unit === 'hours' ? 'horas' : 'días';
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">{balance.absenceTypeName}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div className="flex justify-between text-sm">
+          <span className="text-muted-foreground">Máximo anual:</span>
+          <span className="font-medium">
+            {balance.maxPerYear} {unitLabel}
+          </span>
+        </div>
+        <div className="flex justify-between text-sm">
+          <span className="text-muted-foreground">Consumido:</span>
+          <span className="font-medium">
+            {balance.consumed} {unitLabel}
+          </span>
+        </div>
+        <div className="flex justify-between text-sm">
+          <span className="text-muted-foreground">Restante:</span>
+          <span className="font-semibold text-primary">
+            {balance.remaining} {unitLabel}
+          </span>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/dashboard/PendingValidationsList.tsx
+++ b/apps/web/src/components/dashboard/PendingValidationsList.tsx
@@ -1,0 +1,100 @@
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+import { useNavigate } from '@tanstack/react-router';
+
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
+import type { PendingValidation } from '../../lib/api-client';
+
+interface PendingValidationsListProps {
+  validations: PendingValidation[];
+}
+
+/**
+ * PendingValidationsList component displays absences pending validation.
+ *
+ * Only shown to validators.
+ * Each item shows:
+ * - User name
+ * - Absence type name
+ * - Start and end dates
+ * - Duration
+ * - Creation date
+ *
+ * Clicking on a validation navigates to the absence detail page.
+ *
+ * Part of RF-55 (Dashboard view).
+ */
+export function PendingValidationsList({ validations }: PendingValidationsListProps) {
+  const navigate = useNavigate();
+
+  const handleValidationClick = (absenceId: string) => {
+    void navigate({ to: `/absences/${absenceId}` });
+  };
+
+  if (validations.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Validaciones pendientes</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">No tienes validaciones pendientes.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Validaciones pendientes</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-3">
+          {validations.map((validation) => {
+            const startDate = format(new Date(validation.startAt), 'dd MMM yyyy', { locale: es });
+            const endDate = format(new Date(validation.endAt), 'dd MMM yyyy', { locale: es });
+            const createdDate = format(new Date(validation.createdAt), 'dd MMM yyyy', {
+              locale: es,
+            });
+            const unitLabel =
+              validation.duration === 1
+                ? validation.duration % 1 === 0
+                  ? 'día'
+                  : 'hora'
+                : validation.duration % 1 === 0
+                  ? 'días'
+                  : 'horas';
+
+            return (
+              <li
+                key={validation.id}
+                className="flex flex-col space-y-1 rounded-lg border p-3 cursor-pointer hover:bg-accent transition-colors"
+                onClick={() => handleValidationClick(validation.id)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    handleValidationClick(validation.id);
+                  }
+                }}
+                role="button"
+                tabIndex={0}
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-sm">{validation.userName}</span>
+                  <span className="text-xs text-muted-foreground">Solicitado: {createdDate}</span>
+                </div>
+                <div className="text-sm text-muted-foreground">{validation.absenceTypeName}</div>
+                <div className="text-xs text-muted-foreground">
+                  {startDate} - {endDate}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  Duración: {validation.duration} {unitLabel}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/dashboard/UpcomingAbsencesList.tsx
+++ b/apps/web/src/components/dashboard/UpcomingAbsencesList.tsx
@@ -1,0 +1,99 @@
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+import { useNavigate } from '@tanstack/react-router';
+
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
+import type { UpcomingAbsence } from '../../lib/api-client';
+
+interface UpcomingAbsencesListProps {
+  absences: UpcomingAbsence[];
+}
+
+/**
+ * UpcomingAbsencesList component displays a list of upcoming absences.
+ *
+ * Shows up to 10 upcoming absences ordered by startAt ASC.
+ * Each item shows:
+ * - Absence type name
+ * - Start and end dates
+ * - Duration
+ * - Status (if applicable)
+ *
+ * Clicking on an absence navigates to its detail page.
+ *
+ * Part of RF-55 (Dashboard view).
+ */
+export function UpcomingAbsencesList({ absences }: UpcomingAbsencesListProps) {
+  const navigate = useNavigate();
+
+  const handleAbsenceClick = (absenceId: string) => {
+    void navigate({ to: `/absences/${absenceId}` });
+  };
+
+  if (absences.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Próximas ausencias</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">No tienes ausencias próximas programadas.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Próximas ausencias</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-3">
+          {absences.map((absence) => {
+            const startDate = format(new Date(absence.startAt), 'dd MMM yyyy', { locale: es });
+            const endDate = format(new Date(absence.endAt), 'dd MMM yyyy', { locale: es });
+            const unitLabel =
+              absence.duration === 1
+                ? absence.duration % 1 === 0
+                  ? 'día'
+                  : 'hora'
+                : absence.duration % 1 === 0
+                  ? 'días'
+                  : 'horas';
+
+            return (
+              <li
+                key={absence.id}
+                className="flex flex-col space-y-1 rounded-lg border p-3 cursor-pointer hover:bg-accent transition-colors"
+                onClick={() => handleAbsenceClick(absence.id)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    handleAbsenceClick(absence.id);
+                  }
+                }}
+                role="button"
+                tabIndex={0}
+              >
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-sm">{absence.absenceTypeName}</span>
+                  {absence.status && (
+                    <span className="text-xs text-muted-foreground capitalize">
+                      {absence.status}
+                    </span>
+                  )}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {startDate} - {endDate}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  Duración: {absence.duration} {unitLabel}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/hooks/use-dashboard.ts
+++ b/apps/web/src/hooks/use-dashboard.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchDashboard } from '../lib/api-client';
+import { dashboardKeys } from '../lib/query-keys/dashboard.keys';
+
+/**
+ * Custom hook to fetch dashboard data (RF-55).
+ *
+ * Returns:
+ * - Balance per absence type (maxPerYear, consumed, remaining)
+ * - Upcoming absences (max 10, ordered by startAt ASC)
+ * - Pending validations (only for validators)
+ */
+export function useDashboard() {
+  return useQuery({
+    queryKey: dashboardKeys.data(),
+    queryFn: fetchDashboard,
+    staleTime: 1000 * 60 * 5, // 5 minutes
+    refetchOnWindowFocus: true,
+  });
+}

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -233,3 +233,42 @@ export async function listCalendarAbsences(): Promise<CalendarAbsence[]> {
   const response = await apiClient.get<CalendarAbsence[]>('/absences/calendar');
   return response.data;
 }
+
+export interface AbsenceTypeBalance {
+  absenceTypeId: string;
+  absenceTypeName: string;
+  unit: 'hours' | 'days';
+  maxPerYear: number;
+  consumed: number;
+  remaining: number;
+}
+
+export interface UpcomingAbsence {
+  id: string;
+  absenceTypeName: string;
+  startAt: string;
+  endAt: string;
+  duration: number;
+  status: AbsenceStatus | null;
+}
+
+export interface PendingValidation {
+  id: string;
+  userName: string;
+  absenceTypeName: string;
+  startAt: string;
+  endAt: string;
+  duration: number;
+  createdAt: string;
+}
+
+export interface DashboardData {
+  balances: AbsenceTypeBalance[];
+  upcomingAbsences: UpcomingAbsence[];
+  pendingValidations: PendingValidation[];
+}
+
+export async function fetchDashboard(): Promise<DashboardData> {
+  const response = await apiClient.get<DashboardData>('/dashboard');
+  return response.data;
+}

--- a/apps/web/src/lib/query-keys/dashboard.keys.ts
+++ b/apps/web/src/lib/query-keys/dashboard.keys.ts
@@ -1,0 +1,4 @@
+export const dashboardKeys = {
+  all: ['dashboard'] as const,
+  data: () => [...dashboardKeys.all, 'data'] as const,
+};

--- a/apps/web/src/pages/dashboard/DashboardPage.test.tsx
+++ b/apps/web/src/pages/dashboard/DashboardPage.test.tsx
@@ -1,0 +1,301 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from '@tanstack/react-router';
+
+import { AbsenceStatus, UserRole } from '@repo/types';
+import type { DashboardData } from '../../lib/api-client';
+import { DashboardPage } from './DashboardPage';
+import { useAuthStore } from '../../store/auth.store';
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers();
+  useAuthStore.getState().clearSession();
+});
+afterAll(() => server.close());
+
+const mockDashboardData: DashboardData = {
+  balances: [
+    {
+      absenceTypeId: '01900000-0000-7000-8000-000000000001',
+      absenceTypeName: 'Vacaciones',
+      unit: 'days',
+      maxPerYear: 22,
+      consumed: 10,
+      remaining: 12,
+    },
+    {
+      absenceTypeId: '01900000-0000-7000-8000-000000000002',
+      absenceTypeName: 'Ausencia no retribuida planeada',
+      unit: 'hours',
+      maxPerYear: 80,
+      consumed: 24,
+      remaining: 56,
+    },
+  ],
+  upcomingAbsences: [
+    {
+      id: '01900000-0000-7000-8000-000000000010',
+      absenceTypeName: 'Vacaciones',
+      startAt: '2026-04-15T00:00:00.000Z',
+      endAt: '2026-04-20T00:00:00.000Z',
+      duration: 5,
+      status: AbsenceStatus.ACCEPTED,
+    },
+    {
+      id: '01900000-0000-7000-8000-000000000011',
+      absenceTypeName: 'Ausencia no retribuida planeada',
+      startAt: '2026-05-10T08:00:00.000Z',
+      endAt: '2026-05-10T12:00:00.000Z',
+      duration: 4,
+      status: null,
+    },
+  ],
+  pendingValidations: [
+    {
+      id: '01900000-0000-7000-8000-000000000020',
+      userName: 'John Doe',
+      absenceTypeName: 'Vacaciones',
+      startAt: '2026-06-01T00:00:00.000Z',
+      endAt: '2026-06-05T00:00:00.000Z',
+      duration: 4,
+      createdAt: '2026-03-01T10:00:00.000Z',
+    },
+  ],
+};
+
+function renderComponent(userRole: UserRole = UserRole.STANDARD) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  // Set up auth store with user
+  useAuthStore.setState({
+    user: {
+      id: '01900000-0000-7000-8000-000000000100',
+      email: 'test@example.com',
+      name: 'Test User',
+      role: userRole,
+      isActive: true,
+    },
+    isLoading: false,
+  });
+
+  const rootRoute = createRootRoute();
+  const dashboardRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/',
+    component: DashboardPage,
+  });
+
+  const absenceDetailRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/absences/$absenceId',
+    component: () => <div>Absence Detail Page</div>,
+  });
+
+  const routeTree = rootRoute.addChildren([dashboardRoute, absenceDetailRoute]);
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  );
+}
+
+describe('DashboardPage', () => {
+  it('shows loading state initially', async () => {
+    let resolveRequest: ((value: unknown) => void) | undefined;
+    const requestPromise = new Promise((resolve) => {
+      resolveRequest = resolve;
+    });
+
+    server.use(
+      http.get('*/dashboard', async () => {
+        await requestPromise;
+        return HttpResponse.json(mockDashboardData);
+      })
+    );
+
+    renderComponent();
+
+    expect(screen.getByText(/cargando datos/i)).toBeInTheDocument();
+
+    resolveRequest?.(null);
+
+    await waitFor(() => {
+      expect(screen.queryByText(/cargando datos/i)).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows error message when fetch fails', async () => {
+    server.use(http.get('*/dashboard', () => HttpResponse.error()));
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(/error al cargar los datos/i)).toBeInTheDocument();
+    });
+  });
+
+  it('renders balance cards for each absence type', async () => {
+    server.use(http.get('*/dashboard', () => HttpResponse.json(mockDashboardData)));
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('Balance de ausencias')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Vacaciones')).toBeInTheDocument();
+    expect(screen.getByText('Ausencia no retribuida planeada')).toBeInTheDocument();
+    expect(screen.getByText('22 días')).toBeInTheDocument();
+    expect(screen.getByText('80 horas')).toBeInTheDocument();
+  });
+
+  it('shows correct consumed and remaining values', async () => {
+    server.use(http.get('*/dashboard', () => HttpResponse.json(mockDashboardData)));
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('Balance de ausencias')).toBeInTheDocument();
+    });
+
+    // Check consumed values
+    expect(screen.getByText('10 días')).toBeInTheDocument();
+    expect(screen.getByText('24 horas')).toBeInTheDocument();
+
+    // Check remaining values
+    expect(screen.getByText('12 días')).toBeInTheDocument();
+    expect(screen.getByText('56 horas')).toBeInTheDocument();
+  });
+
+  it('renders upcoming absences list', async () => {
+    server.use(http.get('*/dashboard', () => HttpResponse.json(mockDashboardData)));
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('Próximas ausencias')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Vacaciones')).toBeInTheDocument();
+    expect(screen.getByText('Ausencia no retribuida planeada')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no upcoming absences', async () => {
+    const emptyData: DashboardData = {
+      ...mockDashboardData,
+      upcomingAbsences: [],
+    };
+
+    server.use(http.get('*/dashboard', () => HttpResponse.json(emptyData)));
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(/no tienes ausencias próximas/i)).toBeInTheDocument();
+    });
+  });
+
+  it('navigates to absence detail when clicking on upcoming absence', async () => {
+    server.use(http.get('*/dashboard', () => HttpResponse.json(mockDashboardData)));
+
+    const user = userEvent.setup();
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('Próximas ausencias')).toBeInTheDocument();
+    });
+
+    const absenceItems = screen.getAllByRole('button');
+    const firstUpcomingAbsence = absenceItems.find((item) =>
+      item.textContent?.includes('Vacaciones')
+    );
+
+    if (firstUpcomingAbsence) {
+      await user.click(firstUpcomingAbsence);
+
+      await waitFor(() => {
+        expect(screen.getByText('Absence Detail Page')).toBeInTheDocument();
+      });
+    }
+  });
+
+  it('shows pending validations for validators', async () => {
+    server.use(http.get('*/dashboard', () => HttpResponse.json(mockDashboardData)));
+
+    renderComponent(UserRole.VALIDATOR);
+
+    await waitFor(() => {
+      expect(screen.getByText('Validaciones pendientes')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+  });
+
+  it('hides pending validations for standard users', async () => {
+    server.use(http.get('*/dashboard', () => HttpResponse.json(mockDashboardData)));
+
+    renderComponent(UserRole.STANDARD);
+
+    await waitFor(() => {
+      expect(screen.getByText('Balance de ausencias')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Validaciones pendientes')).not.toBeInTheDocument();
+  });
+
+  it('shows empty state when no pending validations for validator', async () => {
+    const dataWithoutValidations: DashboardData = {
+      ...mockDashboardData,
+      pendingValidations: [],
+    };
+
+    server.use(http.get('*/dashboard', () => HttpResponse.json(dataWithoutValidations)));
+
+    renderComponent(UserRole.VALIDATOR);
+
+    await waitFor(() => {
+      expect(screen.getByText('Balance de ausencias')).toBeInTheDocument();
+    });
+
+    // Should not show pending validations section when empty
+    expect(screen.queryByText('Validaciones pendientes')).not.toBeInTheDocument();
+  });
+
+  it('shows empty state message when no absence types configured', async () => {
+    const emptyBalances: DashboardData = {
+      ...mockDashboardData,
+      balances: [],
+    };
+
+    server.use(http.get('*/dashboard', () => HttpResponse.json(emptyBalances)));
+
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText(/no hay tipos de ausencia configurados/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/pages/dashboard/DashboardPage.tsx
+++ b/apps/web/src/pages/dashboard/DashboardPage.tsx
@@ -1,8 +1,80 @@
+import { UserRole } from '@repo/types';
+
+import { useDashboard } from '../../hooks/use-dashboard';
+import { useAuthStore } from '../../store/auth.store';
+import { BalanceCard } from '../../components/dashboard/BalanceCard';
+import { UpcomingAbsencesList } from '../../components/dashboard/UpcomingAbsencesList';
+import { PendingValidationsList } from '../../components/dashboard/PendingValidationsList';
+
+/**
+ * DashboardPage component (RF-55).
+ *
+ * Displays:
+ * - Balance per absence type (maxPerYear, consumed, remaining) for current year
+ * - Upcoming absences (max 10, ordered by startAt ASC)
+ * - Pending validations section (only for validators)
+ *
+ * Available to standard and validator users.
+ */
 export function DashboardPage() {
+  const { data, isLoading, error } = useDashboard();
+  const user = useAuthStore((state) => state.user);
+
+  const isValidator = user?.role === UserRole.VALIDATOR;
+
+  if (isLoading) {
+    return (
+      <div className="container mx-auto py-8">
+        <h1 className="text-3xl font-bold mb-8">Dashboard</h1>
+        <p className="text-muted-foreground">Cargando datos...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="container mx-auto py-8">
+        <h1 className="text-3xl font-bold mb-8">Dashboard</h1>
+        <p className="text-destructive">
+          Error al cargar los datos del dashboard. Por favor, intenta de nuevo.
+        </p>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return null;
+  }
+
   return (
-    <div>
-      <h1>Dashboard</h1>
-      <p>Contenido del dashboard pendiente de implementar.</p>
+    <div className="container mx-auto py-8 space-y-8">
+      <h1 className="text-3xl font-bold">Dashboard</h1>
+
+      {/* Balance section */}
+      <section>
+        <h2 className="text-xl font-semibold mb-4">Balance de ausencias</h2>
+        {data.balances.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No hay tipos de ausencia configurados.</p>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {data.balances.map((balance) => (
+              <BalanceCard key={balance.absenceTypeId} balance={balance} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Upcoming absences section */}
+      <section>
+        <UpcomingAbsencesList absences={data.upcomingAbsences} />
+      </section>
+
+      {/* Pending validations section (only for validators) */}
+      {isValidator && data.pendingValidations.length > 0 && (
+        <section>
+          <PendingValidationsList validations={data.pendingValidations} />
+        </section>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Implements the Dashboard UI for issues #109 (frontend dashboard) and #110 (RTL tests).

The dashboard displays:
- **Balance per absence type**: Shows max allowed, consumed, and remaining for each absence type in the current year
- **Upcoming absences**: List of next 10 upcoming absences ordered by start date (clickable to navigate to detail)
- **Pending validations**: Section only visible to validators showing absences awaiting their approval

## Changes

### Components Created
- BalanceCard.tsx: Displays absence type balance with max, consumed, and remaining amounts
- UpcomingAbsencesList.tsx: Shows upcoming absences with navigation to detail page
- PendingValidationsList.tsx: Displays pending validations (validators only)

### Hooks & Query Keys
- use-dashboard.ts: Custom TanStack Query hook for fetching dashboard data
- dashboard.keys.ts: Query keys for dashboard caching

### API Client
- Added TypeScript interfaces matching backend DTOs
- Added fetchDashboard() function to call GET /dashboard endpoint

### Tests
- DashboardPage.test.tsx: 11 comprehensive RTL tests with MSW handlers

## Requirements Fulfilled

- ✅ RF-55: Dashboard view with balance, upcoming absences, and pending validations
- ✅ Issue #109: Frontend Dashboard UI implementation
- ✅ Issue #110: RTL tests for Dashboard

## Technical Details

- Uses TanStack Query for data fetching with 5-minute stale time
- Responsive grid layout with Tailwind CSS
- Proper loading and error states
- Role-based rendering (pending validations only for validators)

Closes #109
Closes #110