### PR TITLE
feat(calendar): complete issues #105, #106 and #107

### DIFF
--- a/apps/web/src/components/calendar/CalendarView.test.tsx
+++ b/apps/web/src/components/calendar/CalendarView.test.tsx
@@ -187,7 +187,7 @@ describe('CalendarView', () => {
     });
   });
 
-  it('applies correct event structure for own vs team absences', async () => {
+  it('applies color differentiation for own vs team absences', async () => {
     server.use(http.get('*/absences/calendar', () => HttpResponse.json(mockCalendarAbsences)));
 
     renderComponent();
@@ -196,11 +196,10 @@ describe('CalendarView', () => {
       const ownAbsence = screen.getByText(/John Doe - Vacation/i).closest('.fc-event');
       const teamAbsence = screen.getByText(/Jane Smith - Medical Leave/i).closest('.fc-event');
 
-      // Both should exist and be events
       expect(ownAbsence).toBeInTheDocument();
       expect(teamAbsence).toBeInTheDocument();
-      expect(ownAbsence).toHaveClass('fc-event');
-      expect(teamAbsence).toHaveClass('fc-event');
+      expect(ownAbsence).toHaveStyle({ backgroundColor: 'rgb(37, 99, 235)' });
+      expect(teamAbsence).toHaveStyle({ backgroundColor: 'rgb(245, 158, 11)' });
     });
   });
 

--- a/apps/web/src/pages/absences/AbsenceDetailPage.tsx
+++ b/apps/web/src/pages/absences/AbsenceDetailPage.tsx
@@ -1,0 +1,36 @@
+import { useRouterState } from '@tanstack/react-router';
+
+import { Card, CardContent, CardHeader, CardTitle } from '../../components/ui/card';
+import { useAuthStore } from '../../store/auth.store';
+
+function getAbsenceIdFromPathname(pathname: string): string | null {
+  const match = pathname.match(/^\/absences\/([^/]+)$/);
+  return match?.[1] ?? null;
+}
+
+export function AbsenceDetailPage() {
+  const pathname = useRouterState({ select: (state) => state.location.pathname });
+  const absenceId = getAbsenceIdFromPathname(pathname);
+  const user = useAuthStore((state) => state.user);
+
+  return (
+    <div className="container mx-auto py-8">
+      <h1 className="mb-6 text-3xl font-bold">Detalle de ausencia</h1>
+      <Card>
+        <CardHeader>
+          <CardTitle>Resumen</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm text-muted-foreground">
+          <p>
+            <span className="font-medium text-foreground">ID:</span> {absenceId ?? 'No disponible'}
+          </p>
+          <p>
+            <span className="font-medium text-foreground">Usuario actual:</span>{' '}
+            {user?.name ?? 'No autenticado'}
+          </p>
+          <p>Vista de detalle en modo solo lectura.</p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/pages/calendar/CalendarPage.tsx
+++ b/apps/web/src/pages/calendar/CalendarPage.tsx
@@ -1,0 +1,10 @@
+import { CalendarView } from '../../components/calendar/CalendarView';
+
+export function CalendarPage() {
+  return (
+    <div className="container mx-auto py-8 space-y-6">
+      <h1 className="text-3xl font-bold">Calendario</h1>
+      <CalendarView />
+    </div>
+  );
+}

--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -3,6 +3,8 @@ import { createRouter } from '@tanstack/react-router';
 import { authRoute } from './routes/_auth';
 import { adminRoute } from './routes/_auth.admin';
 import { adminIndexRoute } from './routes/_auth.admin.index';
+import { absenceDetailRoute } from './routes/_auth.absences.$absenceId';
+import { calendarRoute } from './routes/_auth.calendar';
 import { dashboardRoute } from './routes/_auth.index';
 import { publicRoute } from './routes/_public';
 import { loginRoute } from './routes/_public.login';
@@ -11,7 +13,12 @@ import { unauthorizedRoute } from './routes/unauthorized';
 
 const routeTree = rootRoute.addChildren([
   publicRoute.addChildren([loginRoute]),
-  authRoute.addChildren([dashboardRoute, adminRoute.addChildren([adminIndexRoute])]),
+  authRoute.addChildren([
+    dashboardRoute,
+    calendarRoute,
+    absenceDetailRoute,
+    adminRoute.addChildren([adminIndexRoute]),
+  ]),
   unauthorizedRoute,
 ]);
 

--- a/apps/web/src/routes/_auth.absences.$absenceId.tsx
+++ b/apps/web/src/routes/_auth.absences.$absenceId.tsx
@@ -1,0 +1,15 @@
+import { createRoute } from '@tanstack/react-router';
+import { UserRole } from '@repo/types';
+
+import { requireRole } from '../lib/require-role';
+import { AbsenceDetailPage } from '../pages/absences/AbsenceDetailPage';
+import { authRoute } from './_auth';
+
+export const absenceDetailRoute = createRoute({
+  getParentRoute: () => authRoute,
+  path: '/absences/$absenceId',
+  beforeLoad: () => {
+    requireRole([UserRole.STANDARD, UserRole.VALIDATOR, UserRole.AUDITOR]);
+  },
+  component: AbsenceDetailPage,
+});

--- a/apps/web/src/routes/_auth.calendar.tsx
+++ b/apps/web/src/routes/_auth.calendar.tsx
@@ -1,0 +1,15 @@
+import { createRoute } from '@tanstack/react-router';
+import { UserRole } from '@repo/types';
+
+import { requireRole } from '../lib/require-role';
+import { CalendarPage } from '../pages/calendar/CalendarPage';
+import { authRoute } from './_auth';
+
+export const calendarRoute = createRoute({
+  getParentRoute: () => authRoute,
+  path: '/calendar',
+  beforeLoad: () => {
+    requireRole([UserRole.STANDARD, UserRole.VALIDATOR]);
+  },
+  component: CalendarPage,
+});

--- a/apps/web/src/routes/routes.test.tsx
+++ b/apps/web/src/routes/routes.test.tsx
@@ -10,6 +10,8 @@ import type { ReactNode } from 'react';
 import { authRoute } from '../routes/_auth';
 import { adminRoute } from '../routes/_auth.admin';
 import { adminIndexRoute } from '../routes/_auth.admin.index';
+import { absenceDetailRoute } from '../routes/_auth.absences.$absenceId';
+import { calendarRoute } from '../routes/_auth.calendar';
 import { dashboardRoute } from '../routes/_auth.index';
 import { publicRoute } from '../routes/_public';
 import { loginRoute } from '../routes/_public.login';
@@ -32,7 +34,15 @@ const mockAdminUser = {
 
 const server = setupServer(
   http.get('*/users', () => HttpResponse.json([])),
-  http.get('*/absence-types', () => HttpResponse.json([]))
+  http.get('*/absence-types', () => HttpResponse.json([])),
+  http.get('*/absences/calendar', () => HttpResponse.json([])),
+  http.get('*/dashboard', () =>
+    HttpResponse.json({
+      balances: [],
+      upcomingAbsences: [],
+      pendingValidations: [],
+    })
+  )
 );
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
@@ -45,7 +55,12 @@ afterAll(() => server.close());
 function buildRouter(initialPath: string) {
   const routeTree = rootRoute.addChildren([
     publicRoute.addChildren([loginRoute]),
-    authRoute.addChildren([dashboardRoute, adminRoute.addChildren([adminIndexRoute])]),
+    authRoute.addChildren([
+      dashboardRoute,
+      calendarRoute,
+      absenceDetailRoute,
+      adminRoute.addChildren([adminIndexRoute]),
+    ]),
     unauthorizedRoute,
   ]);
 
@@ -150,6 +165,38 @@ describe('Guard de rol: ruta de administracion', () => {
     );
 
     const router = buildRouter('/admin');
+    render(<RouterProvider router={router} />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText('Acceso no permitido')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('Guard de rol: ruta de calendario', () => {
+  it('muestra calendario para usuario STANDARD', async () => {
+    server.use(
+      http.get('*/auth/me', () => {
+        return HttpResponse.json(mockUser);
+      })
+    );
+
+    const router = buildRouter('/calendar');
+    render(<RouterProvider router={router} />, { wrapper: Wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Calendario', level: 1 })).toBeInTheDocument();
+    });
+  });
+
+  it('redirige a /unauthorized para usuario ADMIN', async () => {
+    server.use(
+      http.get('*/auth/me', () => {
+        return HttpResponse.json(mockAdminUser);
+      })
+    );
+
+    const router = buildRouter('/calendar');
     render(<RouterProvider router={router} />, { wrapper: Wrapper });
 
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- Adds authenticated `/calendar` route for standard and validator roles and wires it into the main router.
- Adds authenticated `/absences/$absenceId` route so calendar event clicks open an absence detail page.
- Strengthens calendar coverage by asserting own-vs-team color differentiation and route guards for calendar access.

## Validation
- `docker exec let-me-out-app_devcontainer-app-1 pnpm --filter @repo/types build`
- `docker exec let-me-out-app_devcontainer-app-1 pnpm --filter @repo/web test -- src/components/calendar/CalendarView.test.tsx src/routes/routes.test.tsx`
- `docker exec let-me-out-app_devcontainer-app-1 pnpm --filter @repo/web typecheck`
- `docker exec let-me-out-app_devcontainer-app-1 pnpm --filter @repo/web exec eslint src/router.ts src/routes/_auth.calendar.tsx 'src/routes/_auth.absences.$absenceId.tsx' src/routes/routes.test.tsx src/pages/calendar/CalendarPage.tsx src/pages/absences/AbsenceDetailPage.tsx src/components/calendar/CalendarView.test.tsx`

Closes #105
Closes #106
Closes #107