### PR TITLE
chore(api): fix Prisma env loading from repo root

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ Usa `.env.example` como base.
 - `pnpm --filter @repo/api prisma:migrate`: migraciones en desarrollo
 - `pnpm --filter @repo/api prisma:studio`: UI de Prisma
 
+Los scripts de Prisma en `apps/api` cargan automaticamente el archivo `.env` de la raiz (`../../.env`).
+
 ### apps/web
 
 - `pnpm --filter @repo/web dev`: frontend (placeholder por ahora)

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -7,9 +7,9 @@
     "dev": "nest start --watch",
     "format": "prettier --check .",
     "lint": "eslint \"**/*.{ts,tsx,js,jsx}\" --max-warnings=0 --no-error-on-unmatched-pattern",
-    "prisma:generate": "prisma generate --schema ./prisma/schema.prisma",
-    "prisma:migrate": "prisma migrate dev --schema ./prisma/schema.prisma",
-    "prisma:studio": "prisma studio --schema ./prisma/schema.prisma",
+    "prisma:generate": "node --env-file=../../.env ./node_modules/prisma/build/index.js generate --schema ./prisma/schema.prisma",
+    "prisma:migrate": "node --env-file=../../.env ./node_modules/prisma/build/index.js migrate dev --schema ./prisma/schema.prisma",
+    "prisma:studio": "node --env-file=../../.env ./node_modules/prisma/build/index.js studio --schema ./prisma/schema.prisma",
     "test": "jest",
     "typecheck": "tsc --noEmit"
   },


### PR DESCRIPTION
## Summary
- Updates `apps/api` Prisma scripts (`prisma:generate`, `prisma:migrate`, `prisma:studio`) to always load `../../.env`.
- Aligns Prisma scripts with existing seed behavior that already loads the root env file.
- Documents this behavior in `README.md` under API package commands.

## Why
Running Prisma commands from `apps/api` did not find `DATABASE_URL` when the variable existed only in root `.env`. This caused `P1012` (env var not found).

## Validation
- `docker exec devcontainer-app-1 sh -lc "cd /workspace/apps/api && pnpm prisma:generate"` ✅
- `docker exec devcontainer-app-1 sh -lc "cd /workspace/apps/api && node --env-file=../../.env ./node_modules/prisma/build/index.js migrate status --schema ./prisma/schema.prisma"` reaches datasource config (fails later only if DB host is unreachable, confirming env loading works).