### PR TITLE
fix(api): resolve backend startup regressions after audit changes

### DIFF
--- a/apps/api/src/modules/absences/infrastructure/audit.prisma.repository.ts
+++ b/apps/api/src/modules/absences/infrastructure/audit.prisma.repository.ts
@@ -47,17 +47,28 @@ export class AuditPrismaRepository implements AbsenceAuditRepositoryPort {
   }): Promise<AuditAbsencePage> {
     const where = this.buildWhere(params.filters);
 
-    const records = (await this.prisma.absence.findMany({
-      where,
-      include: {
-        user: { select: { name: true } },
-        absence_type: { select: { name: true } },
-      },
-      orderBy: { id: 'asc' },
-      take: params.limit + 1,
-      skip: params.cursor ? 1 : 0,
-      cursor: params.cursor ? { id: params.cursor } : undefined,
-    })) as AuditAbsencePrismaRecord[];
+    const records = (await (params.cursor
+      ? this.prisma.absence.findMany({
+          where,
+          include: {
+            user: { select: { name: true } },
+            absence_type: { select: { name: true } },
+          },
+          orderBy: { id: 'asc' },
+          take: params.limit + 1,
+          skip: 1,
+          cursor: { id: params.cursor },
+        })
+      : this.prisma.absence.findMany({
+          where,
+          include: {
+            user: { select: { name: true } },
+            absence_type: { select: { name: true } },
+          },
+          orderBy: { id: 'asc' },
+          take: params.limit + 1,
+          skip: 0,
+        }))) as AuditAbsencePrismaRecord[];
 
     return this.toPage(records, params.limit);
   }
@@ -71,17 +82,28 @@ export class AuditPrismaRepository implements AbsenceAuditRepositoryPort {
     const where = this.buildWhere(params.filters);
     where.user_id = params.userId;
 
-    const records = (await this.prisma.absence.findMany({
-      where,
-      include: {
-        user: { select: { name: true } },
-        absence_type: { select: { name: true } },
-      },
-      orderBy: { id: 'asc' },
-      take: params.limit + 1,
-      skip: params.cursor ? 1 : 0,
-      cursor: params.cursor ? { id: params.cursor } : undefined,
-    })) as AuditAbsencePrismaRecord[];
+    const records = (await (params.cursor
+      ? this.prisma.absence.findMany({
+          where,
+          include: {
+            user: { select: { name: true } },
+            absence_type: { select: { name: true } },
+          },
+          orderBy: { id: 'asc' },
+          take: params.limit + 1,
+          skip: 1,
+          cursor: { id: params.cursor },
+        })
+      : this.prisma.absence.findMany({
+          where,
+          include: {
+            user: { select: { name: true } },
+            absence_type: { select: { name: true } },
+          },
+          orderBy: { id: 'asc' },
+          take: params.limit + 1,
+          skip: 0,
+        }))) as AuditAbsencePrismaRecord[];
 
     return this.toPage(records, params.limit);
   }
@@ -117,8 +139,8 @@ export class AuditPrismaRepository implements AbsenceAuditRepositoryPort {
 
     if (filters.startDate || filters.endDate) {
       where.start_at = {
-        gte: filters.startDate,
-        lte: filters.endDate,
+        ...(filters.startDate ? { gte: filters.startDate } : {}),
+        ...(filters.endDate ? { lte: filters.endDate } : {}),
       };
     }
 

--- a/apps/api/src/modules/observations/domain/services/file-validation.service.spec.ts
+++ b/apps/api/src/modules/observations/domain/services/file-validation.service.spec.ts
@@ -2,23 +2,37 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { BadRequestException } from '@nestjs/common';
 import { FileValidationService } from './file-validation.service';
 
-// Mock file-type since it's ESM-only
-jest.mock('file-type', () => ({
-  fileTypeFromBuffer: jest.fn(),
-}));
+class TestableFileValidationService extends FileValidationService {
+  constructor(
+    private readonly detector: jest.Mock<Promise<{ mime: string } | undefined>, [Buffer]>
+  ) {
+    super();
+  }
 
-// Import after mocking
-import { fileTypeFromBuffer } from 'file-type';
+  protected override async detectFileType(buffer: Buffer): Promise<{ mime: string } | undefined> {
+    return this.detector(buffer);
+  }
+}
 
 describe('FileValidationService', () => {
-  let service: FileValidationService;
+  let service: TestableFileValidationService;
+  let detectFileTypeMock: jest.Mock<Promise<{ mime: string } | undefined>, [Buffer]>;
 
   beforeEach(async () => {
+    detectFileTypeMock = jest.fn();
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [FileValidationService],
+      providers: [
+        {
+          provide: FileValidationService,
+          useFactory: () => new TestableFileValidationService(detectFileTypeMock),
+        },
+      ],
     }).compile();
 
-    service = module.get<FileValidationService>(FileValidationService);
+    service = module.get<FileValidationService>(
+      FileValidationService
+    ) as TestableFileValidationService;
     jest.clearAllMocks();
   });
 
@@ -27,6 +41,8 @@ describe('FileValidationService', () => {
   });
 
   describe('validateFile', () => {
+    const bytes = (size: number, value = 0): number[] => new Array<number>(size).fill(value);
+
     it('should reject a file larger than 5 MB', async () => {
       const largeBuffer = Buffer.alloc(6 * 1024 * 1024); // 6 MB
 
@@ -39,8 +55,8 @@ describe('FileValidationService', () => {
     });
 
     it('should accept a JPEG file with valid magic bytes', async () => {
-      const jpegBuffer = Buffer.from([0xFF, 0xD8, 0xFF, 0xE0, ...Array.from({length: 100}).fill(0)]);
-      (fileTypeFromBuffer as jest.Mock).mockResolvedValue({
+      const jpegBuffer = Buffer.from([0xff, 0xd8, 0xff, 0xe0, ...bytes(100)]);
+      detectFileTypeMock.mockResolvedValue({
         mime: 'image/jpeg',
       });
 
@@ -53,15 +69,15 @@ describe('FileValidationService', () => {
       const pngBuffer = Buffer.from([
         0x89,
         0x50,
-        0x4E,
+        0x4e,
         0x47,
-        0x0D,
-        0x0A,
-        0x1A,
-        0x0A,
-        ...Array.from({length: 100}).fill(0),
+        0x0d,
+        0x0a,
+        0x1a,
+        0x0a,
+        ...bytes(100),
       ]);
-      (fileTypeFromBuffer as jest.Mock).mockResolvedValue({
+      detectFileTypeMock.mockResolvedValue({
         mime: 'image/png',
       });
 
@@ -76,13 +92,13 @@ describe('FileValidationService', () => {
         0x50,
         0x44,
         0x46,
-        0x2D,
+        0x2d,
         0x31,
-        0x2E,
+        0x2e,
         0x34,
-        ...Array.from({length: 100}).fill(0),
+        ...bytes(100),
       ]);
-      (fileTypeFromBuffer as jest.Mock).mockResolvedValue({
+      detectFileTypeMock.mockResolvedValue({
         mime: 'application/pdf',
       });
 
@@ -92,8 +108,8 @@ describe('FileValidationService', () => {
     });
 
     it('should reject a file with unsupported MIME type based on magic bytes', async () => {
-      const gifBuffer = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x39, 0x61, ...Array.from({length: 100}).fill(0)]);
-      (fileTypeFromBuffer as jest.Mock).mockResolvedValue({
+      const gifBuffer = Buffer.from([0x47, 0x49, 0x46, 0x38, 0x39, 0x61, ...bytes(100)]);
+      detectFileTypeMock.mockResolvedValue({
         mime: 'image/gif',
       });
 
@@ -104,8 +120,8 @@ describe('FileValidationService', () => {
     });
 
     it('should reject a file with no detectable MIME type', async () => {
-      const randomBuffer = Buffer.from(Array.from({length: 100}).fill(0x00));
-      (fileTypeFromBuffer as jest.Mock).mockResolvedValue();
+      const randomBuffer = Buffer.from(bytes(100, 0x00));
+      detectFileTypeMock.mockResolvedValue(undefined);
 
       await expect(service.validateFile(randomBuffer, 'test.txt')).rejects.toThrow(
         BadRequestException
@@ -117,7 +133,7 @@ describe('FileValidationService', () => {
 
     it('should reject a file that claims to be JPEG but has wrong magic bytes', async () => {
       const fakeJpegBuffer = Buffer.from('This is not a JPEG file');
-      (fileTypeFromBuffer as jest.Mock).mockResolvedValue();
+      detectFileTypeMock.mockResolvedValue(undefined);
 
       await expect(service.validateFile(fakeJpegBuffer, 'fake.jpg')).rejects.toThrow(
         BadRequestException
@@ -126,7 +142,7 @@ describe('FileValidationService', () => {
 
     it('should accept a file exactly 5 MB in size', async () => {
       const exactSizeBuffer = Buffer.alloc(5 * 1024 * 1024);
-      (fileTypeFromBuffer as jest.Mock).mockResolvedValue({
+      detectFileTypeMock.mockResolvedValue({
         mime: 'application/pdf',
       });
 

--- a/apps/api/src/modules/observations/domain/services/file-validation.service.ts
+++ b/apps/api/src/modules/observations/domain/services/file-validation.service.ts
@@ -1,5 +1,4 @@
 import { Injectable, BadRequestException } from '@nestjs/common';
-import { fileTypeFromBuffer } from 'file-type';
 
 const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'application/pdf'] as const;
 const MAX_FILE_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB
@@ -16,6 +15,11 @@ export type AllowedMimeType = (typeof ALLOWED_MIME_TYPES)[number];
  */
 @Injectable()
 export class FileValidationService {
+  protected async detectFileType(buffer: Buffer): Promise<{ mime: string } | undefined> {
+    const { fileTypeFromBuffer } = await import('file-type');
+    return fileTypeFromBuffer(buffer);
+  }
+
   /**
    * Validates a file buffer and returns its validated MIME type.
    * Throws BadRequestException if validation fails.
@@ -29,7 +33,7 @@ export class FileValidationService {
     }
 
     // Non-negotiable 1.9: Validate MIME type using magic bytes
-    const fileType = await fileTypeFromBuffer(buffer);
+    const fileType = await this.detectFileType(buffer);
 
     if (!fileType) {
       throw new BadRequestException(

--- a/apps/api/src/modules/observations/observations.module.ts
+++ b/apps/api/src/modules/observations/observations.module.ts
@@ -13,7 +13,6 @@ import { ListObservationsHandler } from './application/queries/list-observations
 import { OBSERVATION_ATTACHMENT_REPOSITORY_PORT } from './domain/ports/observation-attachment.repository.port';
 import { FILE_STORAGE_PORT } from './domain/ports/file-storage.port';
 import { ObservationAttachmentPrismaRepository } from './infrastructure/observation-attachment.prisma.repository';
-import { ObservationAttachmentMapper } from './infrastructure/observation-attachment.mapper';
 import { LocalFileStorageService } from './infrastructure/local-file-storage.service';
 import { FileValidationService } from './domain/services/file-validation.service';
 import { ObservationAttachmentsController } from './infrastructure/observation-attachments.controller';
@@ -47,7 +46,6 @@ const queryHandlers = [ListObservationsHandler, DownloadAttachmentHandler, ListA
     FileValidationService,
     // Mappers
     ObservationMapper,
-    ObservationAttachmentMapper,
     // Handlers
     ...commandHandlers,
     ...queryHandlers,


### PR DESCRIPTION
## Summary
- Fixes strict TypeScript issues in `audit.prisma.repository.ts` caused by `exactOptionalPropertyTypes` when using optional Prisma `cursor` and date filters.
- Reworks `FileValidationService` to lazily import `file-type` at runtime, avoiding startup crashes with Node 24 and ESM package exports.
- Updates `FileValidationService` tests to use an overridable detector method instead of module-level ESM mocking.
- Removes a non-provider mapper object from `ObservationsModule` providers list.

## Validation
- `docker exec devcontainer-app-1 sh -lc "cd /workspace/apps/api && pnpm build"`
- `docker exec devcontainer-app-1 sh -lc "cd /workspace/apps/api && pnpm test -- src/modules/observations/domain/services/file-validation.service.spec.ts"`

## Context
These fixes were previously committed to a merged branch and are now reintroduced in an isolated PR so they can be reviewed and merged properly.