### PR TITLE
docs(requirements): Clarifies RF-32 final-state exception for cancellation

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -124,7 +124,7 @@
 - El usuario creador puede reenviar la ausencia a validación → vuelve a **"Esperando validación"**.
 - El usuario creador puede decidir no continuar con la solicitud → pasa a **"Descartada"**.
 
-**RF-32** Los estados **"Aceptada"** y **"Descartada"** son estados finales; no se permite ninguna transición posterior.
+**RF-32** El estado **"Descartada"** es final y no permite transiciones posteriores. El estado **"Aceptada"** se considera final para el flujo de validación ordinario y solo admite una transición excepcional a **"Cancelada"** según lo definido en RF-51 y RF-52.
 
 ### 4.3 Acciones de los validadores
 


### PR DESCRIPTION
## Summary
- Clarifies RF-32 to remove ambiguity with RF-51/RF-52 about transitions from `Aceptada`.
- Defines `Descartada` as always final, and `Aceptada` as final for ordinary validation with one exceptional transition to `Cancelada`.
- Aligns requirements wording with the intended state model used by implementation and tests.

## Issue
- Refs #223