### PR TITLE
feat(types): Adds ResendActivationSchema, removes password from CreateUserSchema (#240)

### DIFF
--- a/apps/web/src/components/users/UserFormDialog.test.tsx
+++ b/apps/web/src/components/users/UserFormDialog.test.tsx
@@ -52,7 +52,7 @@ describe('UserFormDialog: modo crear', () => {
     expect(screen.getByRole('heading', { name: 'Nuevo usuario' })).toBeInTheDocument();
     expect(screen.getByLabelText('Nombre')).toBeInTheDocument();
     expect(screen.getByLabelText('Correo electrónico')).toBeInTheDocument();
-    expect(screen.getByLabelText('Contraseña')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Contraseña')).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Crear usuario' })).toBeInTheDocument();
   });
 
@@ -73,7 +73,6 @@ describe('UserFormDialog: modo crear', () => {
 
     await user.type(screen.getByLabelText('Nombre'), 'Test User');
     await user.type(screen.getByLabelText('Correo electrónico'), 'not-an-email');
-    await user.type(screen.getByLabelText('Contraseña'), 'secret123');
     await user.click(screen.getByRole('button', { name: 'Crear usuario' }));
 
     await waitFor(() => {
@@ -89,7 +88,6 @@ describe('UserFormDialog: modo crear', () => {
 
     await user.type(screen.getByLabelText('Nombre'), 'Nuevo Usuario');
     await user.type(screen.getByLabelText('Correo electrónico'), 'nuevo@example.com');
-    await user.type(screen.getByLabelText('Contraseña'), 'password123');
     await user.click(screen.getByRole('button', { name: 'Crear usuario' }));
 
     await waitFor(() => {
@@ -106,7 +104,6 @@ describe('UserFormDialog: modo crear', () => {
 
     await user.type(screen.getByLabelText('Nombre'), 'Otro Usuario');
     await user.type(screen.getByLabelText('Correo electrónico'), 'duplicado@example.com');
-    await user.type(screen.getByLabelText('Contraseña'), 'password123');
     await user.click(screen.getByRole('button', { name: 'Crear usuario' }));
 
     await waitFor(() => {
@@ -124,7 +121,6 @@ describe('UserFormDialog: modo crear', () => {
 
     await user.type(screen.getByLabelText('Nombre'), 'Otro Usuario');
     await user.type(screen.getByLabelText('Correo electrónico'), 'otro@example.com');
-    await user.type(screen.getByLabelText('Contraseña'), 'password123');
     await user.click(screen.getByRole('button', { name: 'Crear usuario' }));
 
     await waitFor(() => {

--- a/apps/web/src/components/users/UserFormDialog.tsx
+++ b/apps/web/src/components/users/UserFormDialog.tsx
@@ -77,7 +77,7 @@ function CreateDialog({ open, onOpenChange, onSuccess }: CreateDialogProps) {
     setError,
   } = useForm<CreateFormValues>({
     resolver: zodResolver(CreateUserSchema),
-    defaultValues: { role: UserRole.STANDARD, isActive: true },
+    defaultValues: { role: UserRole.STANDARD },
   });
 
   const onSubmit = async (data: CreateFormValues) => {
@@ -85,7 +85,6 @@ function CreateDialog({ open, onOpenChange, onSuccess }: CreateDialogProps) {
       await createUser({
         email: data.email,
         name: data.name,
-        password: data.password,
         role: data.role,
       });
       reset();
@@ -138,23 +137,6 @@ function CreateDialog({ open, onOpenChange, onSuccess }: CreateDialogProps) {
             {errors.email && (
               <p id="create-email-error" role="alert" className="text-sm text-destructive">
                 {errors.email.message}
-              </p>
-            )}
-          </div>
-
-          <div className="space-y-1.5">
-            <Label htmlFor="create-password">Contraseña</Label>
-            <Input
-              id="create-password"
-              type="password"
-              autoComplete="new-password"
-              aria-invalid={errors.password ? 'true' : undefined}
-              aria-describedby={errors.password ? 'create-password-error' : undefined}
-              {...register('password')}
-            />
-            {errors.password && (
-              <p id="create-password-error" role="alert" className="text-sm text-destructive">
-                {errors.password.message}
               </p>
             )}
           </div>

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -95,7 +95,6 @@ export async function listUsers(): Promise<User[]> {
 export interface CreateUserPayload {
   email: string;
   name: string;
-  password: string;
   role: User['role'];
 }
 

--- a/apps/web/src/pages/admin/AdminPage.test.tsx
+++ b/apps/web/src/pages/admin/AdminPage.test.tsx
@@ -177,7 +177,7 @@ describe('AdminPage: creación de usuario', () => {
     expect(screen.getByRole('heading', { name: 'Nuevo usuario' })).toBeInTheDocument();
     expect(screen.getByLabelText('Nombre')).toBeInTheDocument();
     expect(screen.getByLabelText('Correo electrónico')).toBeInTheDocument();
-    expect(screen.getByLabelText('Contraseña')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Contraseña')).not.toBeInTheDocument();
   });
 
   it('crea un nuevo usuario y actualiza la lista', async () => {
@@ -207,7 +207,6 @@ describe('AdminPage: creación de usuario', () => {
 
     await user.type(screen.getByLabelText('Nombre'), 'Carlos Ruiz');
     await user.type(screen.getByLabelText('Correo electrónico'), 'carlos@example.com');
-    await user.type(screen.getByLabelText('Contraseña'), 'password123');
     await user.click(screen.getByRole('button', { name: 'Crear usuario' }));
 
     await waitFor(() => {

--- a/packages/types/src/schemas.test.ts
+++ b/packages/types/src/schemas.test.ts
@@ -8,6 +8,7 @@ import {
   CreateUserSchema,
   LoginSchema,
   PasswordSchema,
+  ResendActivationSchema,
 } from './schemas';
 
 describe('PasswordSchema', () => {
@@ -98,23 +99,65 @@ describe('LoginSchema', () => {
 });
 
 describe('CreateUserSchema', () => {
-  it('accepts valid payload', () => {
+  it('accepts valid payload without password', () => {
     const result = CreateUserSchema.safeParse({
       email: 'user@example.com',
       name: 'User Name',
-      password: 'secret',
       role: 'standard',
     });
 
     expect(result.success).toBe(true);
   });
 
+  it('rejects payload with invalid email', () => {
+    const result = CreateUserSchema.safeParse({
+      email: 'not-an-email',
+      name: 'User Name',
+      role: 'standard',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
   it('rejects missing name', () => {
     const result = CreateUserSchema.safeParse({
       email: 'user@example.com',
-      password: 'secret',
       role: 'standard',
     });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid role', () => {
+    const result = CreateUserSchema.safeParse({
+      email: 'user@example.com',
+      name: 'User Name',
+      role: 'superadmin',
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('ResendActivationSchema', () => {
+  it('accepts a valid email', () => {
+    const result = ResendActivationSchema.safeParse({
+      email: 'user@example.com',
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an invalid email format', () => {
+    const result = ResendActivationSchema.safeParse({
+      email: 'not-an-email',
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing email', () => {
+    const result = ResendActivationSchema.safeParse({});
 
     expect(result.success).toBe(false);
   });

--- a/packages/types/src/schemas.ts
+++ b/packages/types/src/schemas.ts
@@ -41,11 +41,13 @@ export const LoginSchema = z.object({
 });
 
 export const CreateUserSchema = z.object({
-  email: z.string().email(),
-  name: z.string().min(1),
-  password: z.string().min(1),
-  role: z.nativeEnum(UserRole),
-  isActive: z.boolean().optional(),
+  email: z.string().email('El correo electrónico no es válido.'),
+  name: z.string().min(1, 'El nombre es obligatorio.'),
+  role: z.nativeEnum(UserRole, { message: 'El rol no es válido.' }),
+});
+
+export const ResendActivationSchema = z.object({
+  email: z.string().email('El correo electrónico no es válido.'),
 });
 
 export const CreateAbsenceTypeSchema = z


### PR DESCRIPTION
## Summary

- **`CreateUserSchema`** in `@repo/types`: removes `password` and `isActive` fields (invitation flow — users set their own password during account activation), adds explicit validation messages for email, name and role.
- **`ResendActivationSchema`**: new Zod schema with a validated `email` field, for re-sending activation links to users.
- **`CreateUserPayload`** in `api-client.ts`: removes `password` field to match the updated schema.
- **`UserFormDialog`**: removes the password input from the create-user form and the `createUser()` API call.
- All affected tests updated (`schemas.test.ts`, `UserFormDialog.test.tsx`, `AdminPage.test.tsx`).

## Acceptance criteria

- [x] `CreateUserSchema` exists without a password field (name, email, role).
- [x] `ActivateAccountSchema` exists with activation token and new password — already present from #230.
- [x] `ResendActivationSchema` exists with user email.
- [x] All types and interfaces are correctly exported from `@repo/types`.
- [x] Lint and typecheck pass without errors (pre-existing `AuditPage.tsx` error is unrelated and out of scope).

## Related issue

Closes #240