### PR TITLE
[Backend] Implementar endpoint POST /auth/activate y reenvío del email de activación

### DIFF
--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -1,17 +1,20 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { CqrsModule } from '@nestjs/cqrs';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { LocalStrategy } from './strategies/local.strategy';
 import { AuthService } from './auth.service';
+import { ActivateController } from './activate.controller';
 import { AuthController } from './auth.controller';
 import { MeController } from './me.controller';
 
 @Module({
   imports: [
     ConfigModule,
+    CqrsModule,
     PassportModule.register({
       defaultStrategy: 'jwt',
       session: false,
@@ -27,7 +30,7 @@ import { MeController } from './me.controller';
       }),
     }),
   ],
-  controllers: [AuthController, MeController],
+  controllers: [AuthController, ActivateController, MeController],
   providers: [AuthService, LocalStrategy, JwtStrategy],
   exports: [PassportModule, JwtModule],
 })

--- a/apps/api/src/modules/users/infrastructure/users.controller.ts
+++ b/apps/api/src/modules/users/infrastructure/users.controller.ts
@@ -19,6 +19,7 @@ import { UpdateUserDto } from '../application/dtos/update-user.dto';
 import { CreateUserCommand } from '../application/commands/create-user.command';
 import { UpdateUserCommand } from '../application/commands/update-user.command';
 import { DeactivateUserCommand } from '../application/commands/deactivate-user.command';
+import { ResendActivationCommand } from '../application/commands/resend-activation.command';
 import { ListUsersQuery } from '../application/queries/list-users.query';
 import { GetUserQuery } from '../application/queries/get-user.query';
 
@@ -59,5 +60,11 @@ export class UsersController {
   @HttpCode(HttpStatus.NO_CONTENT)
   async deactivate(@Param('id') id: string): Promise<void> {
     await this.commandBus.execute<DeactivateUserCommand, void>(new DeactivateUserCommand(id));
+  }
+
+  @Post(':id/resend-activation')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async resendActivation(@Param('id') id: string): Promise<void> {
+    await this.commandBus.execute<ResendActivationCommand, void>(new ResendActivationCommand(id));
   }
 }


### PR DESCRIPTION
## Summary

- Registers `ActivateController` in `AuthModule` (with `CqrsModule`) so `POST /auth/activate` is reachable by unauthenticated users
- Adds `POST /users/:id/resend-activation` endpoint to `UsersController` (admin-only via existing `@Roles(UserRole.ADMIN)` guard)
- All handler logic and unit tests (activate success, expired token, already-used token, resend) were pre-existing and continue to pass (279 tests)

## Acceptance criteria met

- [x] `POST /auth/activate` exists, hashes token, compares with DB, sets password and activates user
- [x] `activation_token_hash` and `activation_token_expires_at` set to null after successful activation
- [x] Returns 400 for expired token, 404 for unknown/used token
- [x] `POST /users/:id/resend-activation` exists and is admin-only
- [x] Resend regenerates token and extends expiry 48h
- [x] Unit tests cover all cases
- [x] Lint and typecheck pass

Closes #244