### PR TITLE
[Frontend] Actualizar formulario de creación de usuario (eliminar campo contraseña)

### DIFF
--- a/apps/web/src/components/users/UserFormDialog.test.tsx
+++ b/apps/web/src/components/users/UserFormDialog.test.tsx
@@ -80,11 +80,11 @@ describe('UserFormDialog: modo crear', () => {
     });
   });
 
-  it('llama a onSuccess y cierra el diálogo al crear usuario correctamente', async () => {
+  it('muestra mensaje de confirmación con el email tras crear el usuario', async () => {
     const user = userEvent.setup();
     server.use(http.post('*/users', () => HttpResponse.json({ id: 'new-id' }, { status: 201 })));
 
-    const { onSuccess, onOpenChange } = renderDialog();
+    const { onSuccess } = renderDialog();
 
     await user.type(screen.getByLabelText('Nombre'), 'Nuevo Usuario');
     await user.type(screen.getByLabelText('Correo electrónico'), 'nuevo@example.com');
@@ -92,6 +92,30 @@ describe('UserFormDialog: modo crear', () => {
 
     await waitFor(() => {
       expect(onSuccess).toHaveBeenCalledTimes(1);
+      expect(screen.getByText(/Se ha enviado un email de activación a/)).toBeInTheDocument();
+      expect(screen.getByText('nuevo@example.com')).toBeInTheDocument();
+    });
+
+    expect(screen.getByRole('button', { name: 'Cerrar' })).toBeInTheDocument();
+  });
+
+  it('cierra el diálogo al pulsar Cerrar tras crear el usuario', async () => {
+    const user = userEvent.setup();
+    server.use(http.post('*/users', () => HttpResponse.json({ id: 'new-id' }, { status: 201 })));
+
+    const { onOpenChange } = renderDialog();
+
+    await user.type(screen.getByLabelText('Nombre'), 'Nuevo Usuario');
+    await user.type(screen.getByLabelText('Correo electrónico'), 'nuevo@example.com');
+    await user.click(screen.getByRole('button', { name: 'Crear usuario' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Cerrar' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Cerrar' }));
+
+    await waitFor(() => {
       expect(onOpenChange).toHaveBeenCalledWith(false);
     });
   });

--- a/apps/web/src/components/users/UserFormDialog.tsx
+++ b/apps/web/src/components/users/UserFormDialog.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { isAxiosError } from 'axios';
+import { useState } from 'react';
 import { useForm, Controller } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -68,6 +69,8 @@ interface CreateDialogProps {
 }
 
 function CreateDialog({ open, onOpenChange, onSuccess }: CreateDialogProps) {
+  const [createdEmail, setCreatedEmail] = useState<string | null>(null);
+
   const {
     register,
     handleSubmit,
@@ -87,9 +90,8 @@ function CreateDialog({ open, onOpenChange, onSuccess }: CreateDialogProps) {
         name: data.name,
         role: data.role,
       });
-      reset();
+      setCreatedEmail(data.email);
       onSuccess();
-      onOpenChange(false);
     } catch (error) {
       const message =
         isAxiosError(error) && error.response?.status === 409
@@ -98,6 +100,40 @@ function CreateDialog({ open, onOpenChange, onSuccess }: CreateDialogProps) {
       setError('root', { message });
     }
   };
+
+  const handleClose = () => {
+    reset();
+    setCreatedEmail(null);
+    onOpenChange(false);
+  };
+
+  if (createdEmail !== null) {
+    return (
+      <Dialog open={open} onOpenChange={handleClose}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Usuario creado</DialogTitle>
+          </DialogHeader>
+
+          <div
+            role="status"
+            aria-live="polite"
+            className="rounded-md border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-800"
+          >
+            Se ha enviado un email de activación a{' '}
+            <span className="font-medium">{createdEmail}</span>. El usuario deberá seguir el enlace
+            para establecer su contraseña y activar su cuenta.
+          </div>
+
+          <DialogFooter>
+            <Button type="button" onClick={handleClose}>
+              Cerrar
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    );
+  }
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/apps/web/src/pages/admin/AdminPage.test.tsx
+++ b/apps/web/src/pages/admin/AdminPage.test.tsx
@@ -210,6 +210,12 @@ describe('AdminPage: creación de usuario', () => {
     await user.click(screen.getByRole('button', { name: 'Crear usuario' }));
 
     await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Usuario creado' })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole('button', { name: 'Cerrar' }));
+
+    await waitFor(() => {
       expect(screen.getByText('Carlos Ruiz')).toBeInTheDocument();
     });
 


### PR DESCRIPTION
## Summary

- The create user form already had no password field (done in PR #249)
- Adds an activation email confirmation state: after successful creation the dialog shows a green info box with the email address and a message that an activation email was sent
- The admin dismisses the dialog with a "Cerrar" button
- Updates `UserFormDialog.test.tsx` to assert the confirmation message and the close button
- Updates `AdminPage.test.tsx` to close the confirmation dialog before asserting the updated user list

## Acceptance criteria met

- [x] No password field in the create user form
- [x] Form sends name, email, role to backend
- [x] Shows activation email sent message after successful creation
- [x] Backend errors (409, generic) are shown clearly in the form
- [x] Uses React Hook Form + Zod with `CreateUserSchema` from `@repo/types`
- [x] Component has tests with React Testing Library
- [x] Code passes lint and typecheck (pre-existing AuditPage.tsx TS errors unrelated)

Closes #245