### PR TITLE
feat(teams): Adds delete team capability (#231)

### DIFF
--- a/apps/api/src/modules/teams/application/commands/add-team-member.handler.spec.ts
+++ b/apps/api/src/modules/teams/application/commands/add-team-member.handler.spec.ts
@@ -40,6 +40,7 @@ const makeTeamRepo = (overrides: Partial<TeamRepositoryPort> = {}): TeamReposito
   findById: jest.fn().mockResolvedValue(makeTeam()),
   findAll: jest.fn(),
   save: jest.fn(),
+  delete: jest.fn(),
   addMember: jest.fn(),
   removeMember: jest.fn(),
   isMember: jest.fn().mockResolvedValue(false),

--- a/apps/api/src/modules/teams/application/commands/create-team.handler.spec.ts
+++ b/apps/api/src/modules/teams/application/commands/create-team.handler.spec.ts
@@ -14,6 +14,7 @@ const makeRepo = (overrides: Partial<TeamRepositoryPort> = {}): TeamRepositoryPo
   findById: jest.fn(),
   findAll: jest.fn(),
   save: jest.fn().mockResolvedValue(null),
+  delete: jest.fn(),
   addMember: jest.fn(),
   removeMember: jest.fn(),
   isMember: jest.fn(),

--- a/apps/api/src/modules/teams/application/commands/delete-team.command.ts
+++ b/apps/api/src/modules/teams/application/commands/delete-team.command.ts
@@ -1,0 +1,3 @@
+export class DeleteTeamCommand {
+  constructor(public readonly teamId: string) {}
+}

--- a/apps/api/src/modules/teams/application/commands/delete-team.handler.spec.ts
+++ b/apps/api/src/modules/teams/application/commands/delete-team.handler.spec.ts
@@ -1,0 +1,48 @@
+import { NotFoundException } from '@nestjs/common';
+
+import { Team } from '../../domain/team.entity';
+import type { TeamRepositoryPort } from '../../domain/ports/team.repository.port';
+import { DeleteTeamCommand } from './delete-team.command';
+import { DeleteTeamHandler } from './delete-team.handler';
+
+const NOW = new Date('2025-01-01T00:00:00.000Z');
+
+const makeTeamRepo = (overrides: Partial<TeamRepositoryPort> = {}): TeamRepositoryPort => ({
+  findById: jest.fn().mockResolvedValue(
+    new Team({
+      id: '01900000-0000-7000-8000-000000000001',
+      name: 'Engineering',
+      color: '#123456',
+      createdAt: NOW,
+      updatedAt: NOW,
+    })
+  ),
+  findAll: jest.fn(),
+  save: jest.fn(),
+  delete: jest.fn().mockResolvedValue(undefined),
+  addMember: jest.fn(),
+  removeMember: jest.fn(),
+  isMember: jest.fn(),
+  findMembers: jest.fn().mockResolvedValue([]),
+  ...overrides,
+});
+
+describe('DeleteTeamHandler', () => {
+  it('deletes team when it exists', async () => {
+    const teamRepository = makeTeamRepo();
+    const handler = new DeleteTeamHandler(teamRepository);
+
+    await handler.execute(new DeleteTeamCommand('01900000-0000-7000-8000-000000000001'));
+
+    expect(teamRepository.delete).toHaveBeenCalledWith('01900000-0000-7000-8000-000000000001');
+  });
+
+  it('throws NotFoundException when team does not exist', async () => {
+    const teamRepository = makeTeamRepo({ findById: jest.fn().mockResolvedValue(null) });
+    const handler = new DeleteTeamHandler(teamRepository);
+
+    await expect(handler.execute(new DeleteTeamCommand('missing-team-id'))).rejects.toBeInstanceOf(
+      NotFoundException
+    );
+  });
+});

--- a/apps/api/src/modules/teams/application/commands/delete-team.handler.ts
+++ b/apps/api/src/modules/teams/application/commands/delete-team.handler.ts
@@ -1,0 +1,27 @@
+import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { CommandHandler, type ICommandHandler } from '@nestjs/cqrs';
+
+import {
+  TEAM_REPOSITORY_PORT,
+  type TeamRepositoryPort,
+} from '../../domain/ports/team.repository.port';
+import { DeleteTeamCommand } from './delete-team.command';
+
+@Injectable()
+@CommandHandler(DeleteTeamCommand)
+export class DeleteTeamHandler implements ICommandHandler<DeleteTeamCommand, void> {
+  constructor(
+    @Inject(TEAM_REPOSITORY_PORT)
+    private readonly teamRepository: TeamRepositoryPort
+  ) {}
+
+  async execute(command: DeleteTeamCommand): Promise<void> {
+    const team = await this.teamRepository.findById(command.teamId);
+
+    if (!team) {
+      throw new NotFoundException(`Team with id ${command.teamId} not found`);
+    }
+
+    await this.teamRepository.delete(command.teamId);
+  }
+}

--- a/apps/api/src/modules/teams/application/commands/remove-team-member.handler.spec.ts
+++ b/apps/api/src/modules/teams/application/commands/remove-team-member.handler.spec.ts
@@ -19,6 +19,7 @@ const makeTeamRepo = (overrides: Partial<TeamRepositoryPort> = {}): TeamReposito
   ),
   findAll: jest.fn(),
   save: jest.fn(),
+  delete: jest.fn(),
   addMember: jest.fn(),
   removeMember: jest.fn(),
   isMember: jest.fn().mockResolvedValue(true),

--- a/apps/api/src/modules/teams/application/queries/get-team-members.handler.spec.ts
+++ b/apps/api/src/modules/teams/application/queries/get-team-members.handler.spec.ts
@@ -21,6 +21,7 @@ const makeRepo = (overrides: Partial<TeamRepositoryPort> = {}): TeamRepositoryPo
   findById: jest.fn().mockResolvedValue(makeTeam()),
   findAll: jest.fn().mockResolvedValue([]),
   save: jest.fn(),
+  delete: jest.fn(),
   addMember: jest.fn(),
   removeMember: jest.fn(),
   isMember: jest.fn(),

--- a/apps/api/src/modules/teams/application/queries/list-teams.handler.spec.ts
+++ b/apps/api/src/modules/teams/application/queries/list-teams.handler.spec.ts
@@ -7,6 +7,7 @@ const makeRepo = (overrides: Partial<TeamRepositoryPort> = {}): TeamRepositoryPo
   findById: jest.fn(),
   findAll: jest.fn().mockResolvedValue([]),
   save: jest.fn(),
+  delete: jest.fn(),
   addMember: jest.fn(),
   removeMember: jest.fn(),
   isMember: jest.fn(),

--- a/apps/api/src/modules/teams/domain/ports/team.repository.port.ts
+++ b/apps/api/src/modules/teams/domain/ports/team.repository.port.ts
@@ -13,6 +13,7 @@ export interface TeamRepositoryPort {
   findById(id: string): Promise<Team | null>;
   findAll(): Promise<Team[]>;
   save(team: Team): Promise<void>;
+  delete(teamId: string): Promise<void>;
   addMember(teamId: string, userId: string, joinedAt: Date): Promise<void>;
   removeMember(teamId: string, userId: string): Promise<void>;
   isMember(teamId: string, userId: string): Promise<boolean>;

--- a/apps/api/src/modules/teams/infrastructure/team.prisma.repository.ts
+++ b/apps/api/src/modules/teams/infrastructure/team.prisma.repository.ts
@@ -22,6 +22,13 @@ export class TeamPrismaRepository implements TeamRepositoryPort {
     return records.map((record) => this.mapper.toDomain(record));
   }
 
+  async delete(teamId: string): Promise<void> {
+    await this.prisma.$transaction([
+      this.prisma.team_member.deleteMany({ where: { team_id: teamId } }),
+      this.prisma.team.delete({ where: { id: teamId } }),
+    ]);
+  }
+
   async save(team: Team): Promise<void> {
     await this.prisma.team.create({
       data: {

--- a/apps/api/src/modules/teams/infrastructure/teams.controller.ts
+++ b/apps/api/src/modules/teams/infrastructure/teams.controller.ts
@@ -18,6 +18,7 @@ import { JwtAuthGuard } from '../../auth/guards/jwt-auth.guard';
 import { Roles } from '../../../common';
 import { AddTeamMemberCommand } from '../application/commands/add-team-member.command';
 import { CreateTeamCommand } from '../application/commands/create-team.command';
+import { DeleteTeamCommand } from '../application/commands/delete-team.command';
 import { RemoveTeamMemberCommand } from '../application/commands/remove-team-member.command';
 import { CreateTeamDto } from '../application/dtos/create-team.dto';
 import type { TeamResponseDto } from '../application/dtos/team-response.dto';
@@ -92,5 +93,12 @@ export class TeamsController {
     await this.commandBus.execute<RemoveTeamMemberCommand, void>(
       new RemoveTeamMemberCommand(teamId, userId)
     );
+  }
+
+  @Delete(':teamId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @Roles(UserRole.ADMIN, UserRole.VALIDATOR)
+  async deleteTeam(@Param('teamId') teamId: string): Promise<void> {
+    await this.commandBus.execute<DeleteTeamCommand, void>(new DeleteTeamCommand(teamId));
   }
 }

--- a/apps/api/src/modules/teams/teams.module.ts
+++ b/apps/api/src/modules/teams/teams.module.ts
@@ -6,6 +6,7 @@ import { PrismaModule } from '../../prisma/prisma.module';
 import { UsersModule } from '../users/users.module';
 import { AddTeamMemberHandler } from './application/commands/add-team-member.handler';
 import { CreateTeamHandler } from './application/commands/create-team.handler';
+import { DeleteTeamHandler } from './application/commands/delete-team.handler';
 import { RemoveTeamMemberHandler } from './application/commands/remove-team-member.handler';
 import { ListTeamsHandler } from './application/queries/list-teams.handler';
 import { GetTeamMembersHandler } from './application/queries/get-team-members.handler';
@@ -14,7 +15,12 @@ import { TeamMapper } from './infrastructure/team.mapper';
 import { TeamPrismaRepository } from './infrastructure/team.prisma.repository';
 import { TeamsController } from './infrastructure/teams.controller';
 
-const commandHandlers = [CreateTeamHandler, AddTeamMemberHandler, RemoveTeamMemberHandler];
+const commandHandlers = [
+  CreateTeamHandler,
+  AddTeamMemberHandler,
+  RemoveTeamMemberHandler,
+  DeleteTeamHandler,
+];
 const queryHandlers = [ListTeamsHandler, GetTeamMembersHandler];
 
 @Module({

--- a/apps/web/src/components/teams/TeamsTable.test.tsx
+++ b/apps/web/src/components/teams/TeamsTable.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -37,10 +37,11 @@ describe('TeamsTable', () => {
     expect(screen.getByText('#F59E0B')).toBeInTheDocument();
   });
 
-  it('does not render actions column when onManageMembers is not provided', () => {
+  it('does not render actions column when no action props are provided', () => {
     render(<TeamsTable teams={teams} />);
     expect(screen.queryByText('Acciones')).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Gestionar miembros' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Eliminar' })).not.toBeInTheDocument();
   });
 
   it('renders actions column when onManageMembers is provided', () => {
@@ -60,5 +61,57 @@ describe('TeamsTable', () => {
 
     expect(onManageMembers).toHaveBeenCalledTimes(1);
     expect(onManageMembers).toHaveBeenCalledWith(teams[0]);
+  });
+
+  it('renders delete buttons when onDelete is provided', () => {
+    render(<TeamsTable teams={teams} onDelete={vi.fn()} />);
+    expect(screen.getByText('Acciones')).toBeInTheDocument();
+    const buttons = screen.getAllByRole('button', { name: 'Eliminar' });
+    expect(buttons).toHaveLength(2);
+  });
+
+  it('shows confirmation dialog when delete button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<TeamsTable teams={teams} onDelete={vi.fn()} />);
+
+    const buttons = screen.getAllByRole('button', { name: 'Eliminar' });
+    await user.click(buttons[0]);
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(within(dialog).getByText('Eliminar equipo')).toBeInTheDocument();
+    expect(within(dialog).getByText(/Plataforma/)).toBeInTheDocument();
+  });
+
+  it('calls onDelete with the correct team after confirming', async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+    render(<TeamsTable teams={teams} onDelete={onDelete} />);
+
+    const deleteButtons = screen.getAllByRole('button', { name: 'Eliminar' });
+    await user.click(deleteButtons[0]);
+
+    const dialog = screen.getByRole('dialog');
+    const confirmButton = within(dialog).getByRole('button', { name: 'Eliminar' });
+    await user.click(confirmButton);
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onDelete).toHaveBeenCalledWith(teams[0]);
+  });
+
+  it('closes confirmation dialog when cancel is clicked', async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+    render(<TeamsTable teams={teams} onDelete={onDelete} />);
+
+    const deleteButtons = screen.getAllByRole('button', { name: 'Eliminar' });
+    await user.click(deleteButtons[0]);
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: 'Cancelar' }));
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(onDelete).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/components/teams/TeamsTable.tsx
+++ b/apps/web/src/components/teams/TeamsTable.tsx
@@ -1,10 +1,20 @@
+import { useState } from 'react';
 import type { Team } from '@repo/types';
 
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 
 interface TeamsTableProps {
   teams: Team[];
   onManageMembers?: (team: Team) => void;
+  onDelete?: (team: Team) => void;
 }
 
 function getContrastTextColor(hexColor: string): string {
@@ -17,57 +27,109 @@ function getContrastTextColor(hexColor: string): string {
   return luminance > 0.55 ? '#111827' : '#F9FAFB';
 }
 
-export function TeamsTable({ teams, onManageMembers }: TeamsTableProps) {
+export function TeamsTable({ teams, onManageMembers, onDelete }: TeamsTableProps) {
+  const [teamToDelete, setTeamToDelete] = useState<Team | null>(null);
+
   if (teams.length === 0) {
     return (
       <p className="py-8 text-center text-sm text-muted-foreground">No hay equipos registrados.</p>
     );
   }
 
+  const hasActions = onManageMembers !== undefined || onDelete !== undefined;
+
+  function handleConfirmDelete() {
+    if (teamToDelete) {
+      onDelete?.(teamToDelete);
+      setTeamToDelete(null);
+    }
+  }
+
   return (
-    <div className="overflow-x-auto rounded-lg border border-border">
-      <table className="w-full text-sm">
-        <thead>
-          <tr className="border-b border-border bg-muted text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            <th className="px-4 py-3">Nombre</th>
-            <th className="px-4 py-3">Color</th>
-            {onManageMembers && <th className="px-4 py-3 text-right">Acciones</th>}
-          </tr>
-        </thead>
-        <tbody>
-          {teams.map((team, index) => (
-            <tr
-              key={team.id}
-              className={
-                index % 2 === 0 ? 'bg-card text-foreground' : 'bg-muted/40 text-foreground'
-              }
-            >
-              <td className="px-4 py-3 font-medium">{team.name}</td>
-              <td className="px-4 py-3">
-                <div className="inline-flex items-center gap-2">
-                  <span
-                    className="rounded-md px-2 py-1 text-xs font-semibold"
-                    style={{
-                      backgroundColor: team.color,
-                      color: getContrastTextColor(team.color),
-                    }}
-                  >
-                    {team.color.toUpperCase()}
-                  </span>
-                  <span className="text-xs text-muted-foreground">Color del equipo</span>
-                </div>
-              </td>
-              {onManageMembers && (
-                <td className="px-4 py-3 text-right">
-                  <Button variant="outline" size="sm" onClick={() => onManageMembers(team)}>
-                    Gestionar miembros
-                  </Button>
-                </td>
-              )}
+    <>
+      <div className="overflow-x-auto rounded-lg border border-border">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border bg-muted text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              <th className="px-4 py-3">Nombre</th>
+              <th className="px-4 py-3">Color</th>
+              {hasActions && <th className="px-4 py-3 text-right">Acciones</th>}
             </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+          </thead>
+          <tbody>
+            {teams.map((team, index) => (
+              <tr
+                key={team.id}
+                className={
+                  index % 2 === 0 ? 'bg-card text-foreground' : 'bg-muted/40 text-foreground'
+                }
+              >
+                <td className="px-4 py-3 font-medium">{team.name}</td>
+                <td className="px-4 py-3">
+                  <div className="inline-flex items-center gap-2">
+                    <span
+                      className="rounded-md px-2 py-1 text-xs font-semibold"
+                      style={{
+                        backgroundColor: team.color,
+                        color: getContrastTextColor(team.color),
+                      }}
+                    >
+                      {team.color.toUpperCase()}
+                    </span>
+                    <span className="text-xs text-muted-foreground">Color del equipo</span>
+                  </div>
+                </td>
+                {hasActions && (
+                  <td className="px-4 py-3 text-right">
+                    <div className="inline-flex items-center justify-end gap-2">
+                      {onManageMembers && (
+                        <Button variant="outline" size="sm" onClick={() => onManageMembers(team)}>
+                          Gestionar miembros
+                        </Button>
+                      )}
+                      {onDelete && (
+                        <Button
+                          variant="destructive"
+                          size="sm"
+                          onClick={() => setTeamToDelete(team)}
+                        >
+                          Eliminar
+                        </Button>
+                      )}
+                    </div>
+                  </td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <Dialog
+        open={teamToDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setTeamToDelete(null);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Eliminar equipo</DialogTitle>
+            <DialogDescription>
+              ¿Estás seguro de que quieres eliminar el equipo{' '}
+              <span className="font-semibold">{teamToDelete?.name}</span>? Esta acción no se puede
+              deshacer.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setTeamToDelete(null)}>
+              Cancelar
+            </Button>
+            <Button variant="destructive" onClick={handleConfirmDelete}>
+              Eliminar
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/apps/web/src/hooks/use-teams.ts
+++ b/apps/web/src/hooks/use-teams.ts
@@ -4,6 +4,7 @@ import type { Team } from '@repo/types';
 import {
   addTeamMember,
   createTeam,
+  deleteTeam,
   listTeamMembers,
   listTeams,
   removeTeamMember,
@@ -68,6 +69,17 @@ export function useRemoveTeamMember() {
     onSuccess: (_, { teamId }) => {
       void queryClient.invalidateQueries({ queryKey: teamsKeys.all });
       void queryClient.invalidateQueries({ queryKey: teamsKeys.members(teamId) });
+    },
+  });
+}
+
+export function useDeleteTeam() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (teamId: string) => deleteTeam(teamId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: teamsKeys.all });
     },
   });
 }

--- a/apps/web/src/lib/api-client.ts
+++ b/apps/web/src/lib/api-client.ts
@@ -354,6 +354,10 @@ export interface TeamMemberDto {
   joinedAt: string;
 }
 
+export async function deleteTeam(teamId: string): Promise<void> {
+  await apiClient.delete(`/teams/${teamId}`);
+}
+
 export async function listTeamMembers(teamId: string): Promise<TeamMemberDto[]> {
   const response = await apiClient.get<TeamMemberDto[]>(`/teams/${teamId}/members`);
   return response.data;


### PR DESCRIPTION
## Summary

- Adds  backend endpoint (ADMIN/VALIDATOR roles, 204 No Content) with  to delete team members first, then the team itself
- Adds  +  with  guard; unit-tested
- Adds  API client function and  React hook
- Adds delete button + inline confirmation dialog to  component with 4 new tests

## Related

Closes #231

## Test coverage

- 2 new backend unit tests (: success + not found)
- 4 new frontend tests (: renders delete buttons, shows dialog, calls onDelete, cancel closes dialog)
- All 281 backend tests pass; all frontend tests pass (pre-existing failures in routes/dashboard/login are unrelated to this PR)