### PR TITLE
fix(config): Corrects APP_URL to point to frontend for activation email links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,4 +27,7 @@ SEED_ADMIN_PASSWORD=replace_with_strong_password
 SEED_ADMIN_NAME=Administrador
 
 # Frontend
+# APP_URL: public URL of the frontend — used in activation and password-reset email links.
+# Must point to the frontend origin, NOT the backend.
+APP_URL=http://localhost:5173
 VITE_API_URL=http://localhost:3000

--- a/apps/api/src/config/env.validation.ts
+++ b/apps/api/src/config/env.validation.ts
@@ -13,6 +13,7 @@ export const envValidationSchema = Joi.object({
   SMTP_PASS: Joi.string().required(),
   SMTP_FROM: Joi.string().required(),
   CORS_ORIGIN: Joi.string().required(),
+  APP_URL: Joi.string().uri().required(),
   APP_PORT: Joi.number().port().optional(),
   COOKIE_SAMESITE: Joi.string().valid('none', 'strict').required(),
   COOKIE_SECURE: Joi.boolean().required(),


### PR DESCRIPTION
## Problem

The activation email contained a link pointing to the **backend** URL (e.g. `http://localhost:3050/activate?token=…`) instead of the frontend. The backend has no `GET /activate` route, so following the link returned:

```json
{"statusCode":404,"error":"NOT_FOUND","message":"Cannot GET /activate?token=…"}
```

## Root cause

`APP_URL` is the env variable used by `create-user.handler.ts` and `resend-activation.handler.ts` to build the activation link. It was:

1. **Not present in `.env.example`** — so it was easy to set it to the wrong value (the backend URL) without realising the mistake.
2. **Not validated** in `env.validation.ts` — so a missing or incorrect value caused no startup error and silently produced broken links.

The `/activate` route only exists on the **frontend** (TanStack Router `ActivatePage`), so `APP_URL` must always be the frontend origin.

## Changes

| File | Change |
|---|---|
| `apps/api/src/config/env.validation.ts` | Adds `APP_URL: Joi.string().uri().required()` — startup fails fast if missing or not a URI |
| `.env.example` | Adds `APP_URL=http://localhost:5173` with a comment clarifying it must be the frontend origin |

> **Local `.env` fix (not committed — gitignored):** `APP_URL` changed from `http://localhost:3050` to `http://localhost:5173`.

## Verification

1. Restart the backend — it should start normally with `APP_URL=http://localhost:5173`.
2. Create a new user via the admin panel.
3. Open the activation email in MailDev — the link should now be `http://localhost:5173/activate?token=…`.
4. Follow the link — the frontend `ActivatePage` renders, the user sets a password and is redirected to `/login`.
5. Remove `APP_URL` from `.env` and restart — the backend should refuse to start with a validation error.
