### PR TITLE
fix(absence-types): Allow all authenticated users to read absence types

### DIFF
--- a/apps/api/src/modules/absence-types/infrastructure/absence-types.controller.ts
+++ b/apps/api/src/modules/absence-types/infrastructure/absence-types.controller.ts
@@ -23,7 +23,6 @@ import { DeactivateAbsenceTypeCommand } from '../application/commands/deactivate
 import { ListAbsenceTypesQuery } from '../application/queries/list-absence-types.query';
 import { GetAbsenceTypeQuery } from '../application/queries/get-absence-type.query';
 
-@Roles(UserRole.ADMIN)
 @Controller('absence-types')
 export class AbsenceTypesController {
   constructor(
@@ -31,6 +30,7 @@ export class AbsenceTypesController {
     private readonly queryBus: QueryBus
   ) {}
 
+  @Roles(UserRole.ADMIN)
   @Post()
   async create(@Body() dto: CreateAbsenceTypeDto): Promise<{ id: string }> {
     const id = await this.commandBus.execute<CreateAbsenceTypeCommand, string>(
@@ -63,6 +63,7 @@ export class AbsenceTypesController {
     );
   }
 
+  @Roles(UserRole.ADMIN)
   @Patch(':id')
   async update(@Param('id') id: string, @Body() dto: UpdateAbsenceTypeDto): Promise<void> {
     await this.commandBus.execute<UpdateAbsenceTypeCommand, void>(
@@ -79,6 +80,7 @@ export class AbsenceTypesController {
     );
   }
 
+  @Roles(UserRole.ADMIN)
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
   async deactivate(@Param('id') id: string): Promise<void> {


### PR DESCRIPTION
## Summary

- Fixes empty absence type dropdown for STANDARD and VALIDATOR users when creating absences
- Moves `@Roles(UserRole.ADMIN)` decorator from class level to individual write methods (POST, PATCH, DELETE)
- GET endpoints are now accessible to all authenticated users
- Write operations remain restricted to ADMIN role only

## Changes

- **Modified:** `apps/api/src/modules/absence-types/infrastructure/absence-types.controller.ts`
  - Removed `@Roles(UserRole.ADMIN)` from class decorator
  - Added `@Roles(UserRole.ADMIN)` to `@Post()`, `@Patch(':id')`, and `@Delete(':id')` methods
  - `@Get()` and `@Get(':id')` methods are now accessible to all authenticated users

## Problem

According to RF-23, STANDARD and VALIDATOR users must be able to create absences, which requires them to select an absence type from a dropdown. However, the `GET /absence-types` endpoint was restricted to ADMIN users only, causing the dropdown to be empty.

## Solution

This is a minimal, non-invasive change that follows the principle of least privilege:
- Read operations (GET) are available to all authenticated users (protected by JWT guard)
- Write operations (POST, PATCH, DELETE) remain restricted to ADMIN role

## References

- Issue: docs/pending-fixes-2026-03.md #5
- Related requirements: RF-23 (Creating absences)