### PR TITLE
fix(router): Register missing activate route

### DIFF
--- a/apps/web/src/router.ts
+++ b/apps/web/src/router.ts
@@ -13,6 +13,7 @@ import { publicRoute } from './routes/_public';
 import { loginRoute } from './routes/_public.login';
 import { rootRoute } from './routes/__root';
 import { unauthorizedRoute } from './routes/unauthorized';
+import { activateRoute } from './routes/activate';
 
 const routeTree = rootRoute.addChildren([
   publicRoute.addChildren([loginRoute]),
@@ -25,6 +26,7 @@ const routeTree = rootRoute.addChildren([
     auditRoute.addChildren([auditIndexRoute]),
   ]),
   unauthorizedRoute,
+  activateRoute,
 ]);
 
 export const router = createRouter({ routeTree });


### PR DESCRIPTION
## Summary

- Fixes 404 NotFound error on account activation links
- Registers `activateRoute` in the router tree
- Account activation URLs like `/activate?token=...` now work correctly

## Problem

When a new user receives an activation email and clicks the link (e.g., `http://localhost:5173/activate?token=213a114a...`), the application shows a **NotFound** page.

### Root Cause

The `activateRoute` was defined in `apps/web/src/routes/activate.tsx` but was **never registered** in the route tree in `apps/web/src/router.ts`. TanStack Router requires explicit registration of all routes in the tree.

## Solution

- **Import** `activateRoute` in `router.ts`
- **Register** it as a root-level route in the `routeTree` (alongside `unauthorizedRoute`)

## Changes

- **Modified:** `apps/web/src/router.ts`
  - Added import: `import { activateRoute } from './routes/activate';`
  - Added to route tree: `activateRoute` as a child of `rootRoute`

## Testing

1. Create a new user from admin panel
2. Copy the activation link from the email (console in dev)
3. Navigate to the link
4. ✅ The activation page should now render instead of NotFound
5. ✅ User should be able to set password and activate account

## Impact

- **Critical fix** — users cannot activate their accounts without this
- **No breaking changes** — only adds missing route registration
- **No dependencies** — standalone fix

## References

- Related to user activation flow (RF-02: Only admins can create users)