### PR TITLE
feat(layout): Replaces header nav with collapsible sidebar

### DIFF
--- a/apps/web/src/components/layout/AppNav.test.tsx
+++ b/apps/web/src/components/layout/AppNav.test.tsx
@@ -58,11 +58,12 @@ describe('AppNav', () => {
       });
     });
 
-    it('muestra el enlace de solicitar ausencia', async () => {
+    it('no muestra el enlace de solicitar ausencia', async () => {
       renderNav(UserRole.STANDARD);
       await waitFor(() => {
-        expect(screen.getByRole('link', { name: 'Solicitar ausencia' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Dashboard' })).toBeInTheDocument();
       });
+      expect(screen.queryByRole('link', { name: 'Solicitar ausencia' })).not.toBeInTheDocument();
     });
 
     it('no muestra enlace de auditoría', async () => {
@@ -97,11 +98,12 @@ describe('AppNav', () => {
       });
     });
 
-    it('muestra el enlace de solicitar ausencia', async () => {
+    it('no muestra el enlace de solicitar ausencia', async () => {
       renderNav(UserRole.VALIDATOR);
       await waitFor(() => {
-        expect(screen.getByRole('link', { name: 'Solicitar ausencia' })).toBeInTheDocument();
+        expect(screen.getByRole('link', { name: 'Dashboard' })).toBeInTheDocument();
       });
+      expect(screen.queryByRole('link', { name: 'Solicitar ausencia' })).not.toBeInTheDocument();
     });
 
     it('no muestra enlace de auditoría', async () => {

--- a/apps/web/src/components/layout/AppNav.tsx
+++ b/apps/web/src/components/layout/AppNav.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@tanstack/react-router';
 import { UserRole } from '@repo/types';
+import { CalendarDays, LayoutDashboard, ShieldCheck, type LucideIcon } from 'lucide-react';
 
 import type { SessionUser } from '../../store/auth.store';
 
@@ -10,23 +11,23 @@ interface AppNavProps {
 interface NavLink {
   to: string;
   label: string;
+  icon: LucideIcon;
 }
 
-function getNavLinks(role: UserRole): NavLink[] {
+export function getNavLinks(role: UserRole): NavLink[] {
   switch (role) {
     case UserRole.STANDARD:
     case UserRole.VALIDATOR: {
       return [
-        { to: '/', label: 'Dashboard' },
-        { to: '/calendar', label: 'Calendario' },
-        { to: '/absences/new', label: 'Solicitar ausencia' },
+        { to: '/', label: 'Dashboard', icon: LayoutDashboard },
+        { to: '/calendar', label: 'Calendario', icon: CalendarDays },
       ];
     }
     case UserRole.AUDITOR: {
-      return [{ to: '/audit', label: 'Auditoría' }];
+      return [{ to: '/audit', label: 'Auditoría', icon: ShieldCheck }];
     }
     case UserRole.ADMIN: {
-      return [{ to: '/admin', label: 'Administración' }];
+      return [{ to: '/admin', label: 'Administración', icon: ShieldCheck }];
     }
     default: {
       return [];
@@ -44,9 +45,12 @@ export function AppNav({ user }: AppNavProps) {
           <li key={link.to}>
             <Link
               to={link.to}
-              className="text-sm font-medium hover:underline"
-              activeProps={{ className: 'text-sm font-medium underline' }}
+              className="inline-flex items-center gap-2 text-sm font-medium hover:underline"
+              activeProps={{
+                className: 'inline-flex items-center gap-2 text-sm font-medium underline',
+              }}
             >
+              <link.icon className="h-4 w-4" aria-hidden="true" />
               {link.label}
             </Link>
           </li>

--- a/apps/web/src/components/layout/AppSidebar.test.tsx
+++ b/apps/web/src/components/layout/AppSidebar.test.tsx
@@ -1,0 +1,125 @@
+import {
+  createMemoryHistory,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  RouterProvider,
+} from '@tanstack/react-router';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UserRole, type SessionUser } from '../../store/auth.store';
+import { AppSidebar } from './AppSidebar';
+
+const logoutMock = vi.hoisted(() => vi.fn<[], Promise<void>>());
+
+vi.mock('../../lib/api-client', () => ({
+  logout: logoutMock,
+}));
+
+const storageKey = 'sidebar-collapsed';
+
+function buildTestRouter(user: SessionUser) {
+  const rootRoute = createRootRoute({
+    component: () => <AppSidebar user={user} />,
+  });
+
+  const indexRoute = createRoute({ getParentRoute: () => rootRoute, path: '/' });
+
+  const routeTree = rootRoute.addChildren([indexRoute]);
+
+  return createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  });
+}
+
+function renderSidebar(userRole: UserRole = UserRole.STANDARD) {
+  const user: SessionUser = {
+    id: '01900000-0000-7000-8000-000000000001',
+    name: 'Test User',
+    email: 'test@example.com',
+    role: userRole,
+    isActive: true,
+  };
+
+  const router = buildTestRouter(user);
+  render(<RouterProvider router={router} />);
+}
+
+beforeEach(() => {
+  globalThis.localStorage.clear();
+});
+
+afterEach(() => {
+  logoutMock.mockReset();
+});
+
+describe('AppSidebar', () => {
+  it('renders expanded by default with icon and text labels', async () => {
+    renderSidebar(UserRole.STANDARD);
+
+    await waitFor(() => {
+      expect(screen.getByRole('navigation', { name: 'Navegación principal' })).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Dashboard')).toBeInTheDocument();
+    expect(screen.getByText('Calendario')).toBeInTheDocument();
+    expect(screen.getByText('Test User')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Colapsar barra lateral' })).toHaveAttribute(
+      'aria-expanded',
+      'true'
+    );
+  });
+
+  it('renders collapsed from localStorage with title and aria-label links', async () => {
+    globalThis.localStorage.setItem(storageKey, 'true');
+
+    renderSidebar(UserRole.STANDARD);
+
+    await waitFor(() => {
+      expect(screen.getByRole('navigation', { name: 'Navegación principal' })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('Dashboard')).not.toBeInTheDocument();
+    expect(screen.queryByText('Calendario')).not.toBeInTheDocument();
+    expect(screen.queryByText('Test User')).not.toBeInTheDocument();
+
+    const dashboardLink = screen.getByRole('link', { name: 'Dashboard' });
+    expect(dashboardLink).toHaveAttribute('title', 'Dashboard');
+    const calendarLink = screen.getByRole('link', { name: 'Calendario' });
+    expect(calendarLink).toHaveAttribute('title', 'Calendario');
+
+    expect(screen.getByRole('button', { name: 'Expandir barra lateral' })).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+  });
+
+  it('persists collapsed state changes in localStorage', async () => {
+    const user = userEvent.setup();
+
+    renderSidebar(UserRole.STANDARD);
+
+    const toggleButton = await screen.findByRole('button', { name: 'Colapsar barra lateral' });
+    await user.click(toggleButton);
+
+    expect(globalThis.localStorage.getItem(storageKey)).toBe('true');
+
+    const expandButton = await screen.findByRole('button', { name: 'Expandir barra lateral' });
+    await user.click(expandButton);
+
+    expect(globalThis.localStorage.getItem(storageKey)).toBe('false');
+  });
+
+  it('does not render Solicitar ausencia for standard users', async () => {
+    renderSidebar(UserRole.STANDARD);
+
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Dashboard' })).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('link', { name: 'Solicitar ausencia' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/layout/AppSidebar.tsx
+++ b/apps/web/src/components/layout/AppSidebar.tsx
@@ -1,0 +1,89 @@
+import { Link } from '@tanstack/react-router';
+import { Menu, User } from 'lucide-react';
+import { useState } from 'react';
+
+import { LogoutButton } from './LogoutButton';
+import { getNavLinks } from './AppNav';
+import type { SessionUser } from '../../store/auth.store';
+
+const SIDEBAR_COLLAPSED_STORAGE_KEY = 'sidebar-collapsed';
+
+interface AppSidebarProps {
+  user: SessionUser;
+}
+
+function getInitialCollapsedState(): boolean {
+  if (globalThis.window === undefined) {
+    return false;
+  }
+
+  return globalThis.localStorage.getItem(SIDEBAR_COLLAPSED_STORAGE_KEY) === 'true';
+}
+
+export function AppSidebar({ user }: AppSidebarProps) {
+  const links = getNavLinks(user.role);
+  const [collapsed, setCollapsed] = useState<boolean>(getInitialCollapsedState);
+
+  const handleToggle = () => {
+    setCollapsed((previous) => {
+      const next = !previous;
+      globalThis.localStorage.setItem(SIDEBAR_COLLAPSED_STORAGE_KEY, String(next));
+      return next;
+    });
+  };
+
+  return (
+    <aside
+      aria-label="Menú principal"
+      className={`flex h-screen shrink-0 flex-col border-r bg-background transition-all duration-200 ${collapsed ? 'w-16' : 'w-56'}`}
+    >
+      <div className="flex items-center justify-between gap-2 border-b px-3 py-3">
+        {!collapsed && (
+          <span className="text-sm font-semibold" aria-hidden="true">
+            Let Me Out
+          </span>
+        )}
+        <button
+          type="button"
+          onClick={handleToggle}
+          aria-controls="sidebar-nav"
+          aria-expanded={!collapsed}
+          aria-label={collapsed ? 'Expandir barra lateral' : 'Colapsar barra lateral'}
+          className="inline-flex h-9 w-9 items-center justify-center rounded-md border border-input bg-background text-foreground hover:bg-accent hover:text-accent-foreground"
+        >
+          <Menu className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+
+      <nav id="sidebar-nav" className="px-2 py-3" aria-label="Navegación principal">
+        <ul className="m-0 list-none space-y-1 p-0">
+          {links.map((link) => (
+            <li key={link.to}>
+              <Link
+                to={link.to}
+                title={collapsed ? link.label : undefined}
+                aria-label={link.label}
+                className="inline-flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium text-foreground hover:bg-accent hover:text-accent-foreground"
+                activeProps={{
+                  className:
+                    'inline-flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm font-medium bg-accent text-accent-foreground',
+                }}
+              >
+                <link.icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+                {!collapsed && <span>{link.label}</span>}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+
+      <div className="mt-auto border-t px-3 py-3">
+        <div className="mb-2 flex items-center gap-2 text-sm text-muted-foreground">
+          <User className="h-4 w-4 shrink-0" aria-hidden="true" />
+          {!collapsed && <span aria-label={`Usuario: ${user.name}`}>{user.name}</span>}
+        </div>
+        <LogoutButton collapsed={collapsed} />
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/components/layout/LogoutButton.tsx
+++ b/apps/web/src/components/layout/LogoutButton.tsx
@@ -1,10 +1,15 @@
 import { useNavigate } from '@tanstack/react-router';
+import { LogOut } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { logout } from '../../lib/api-client';
 import { useAuthStore } from '../../store/auth.store';
 
-export function LogoutButton() {
+interface LogoutButtonProps {
+  collapsed?: boolean;
+}
+
+export function LogoutButton({ collapsed = false }: LogoutButtonProps) {
   const navigate = useNavigate();
 
   const handleLogout = async () => {
@@ -14,8 +19,17 @@ export function LogoutButton() {
   };
 
   return (
-    <Button type="button" variant="ghost" size="sm" onClick={() => void handleLogout()}>
-      Cerrar sesión
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      onClick={() => void handleLogout()}
+      className={collapsed ? 'w-full justify-center px-2' : 'w-full justify-start'}
+      title={collapsed ? 'Cerrar sesión' : undefined}
+      aria-label="Cerrar sesión"
+    >
+      <LogOut className="h-4 w-4" aria-hidden="true" />
+      {!collapsed && <span>Cerrar sesión</span>}
     </Button>
   );
 }

--- a/apps/web/src/layouts/AuthLayout.tsx
+++ b/apps/web/src/layouts/AuthLayout.tsx
@@ -1,7 +1,6 @@
 import { Outlet } from '@tanstack/react-router';
 
-import { AppNav } from '../components/layout/AppNav';
-import { LogoutButton } from '../components/layout/LogoutButton';
+import { AppSidebar } from '../components/layout/AppSidebar';
 import type { SessionUser } from '../store/auth.store';
 
 interface AuthLayoutProps {
@@ -10,26 +9,15 @@ interface AuthLayoutProps {
 
 export function AuthLayout({ user }: AuthLayoutProps) {
   return (
-    <div className="auth-layout">
+    <div className="auth-layout flex h-screen flex-row">
       <a
         href="#main-content"
         className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:px-4 focus:py-2 focus:bg-background focus:text-foreground focus:underline"
       >
         Saltar al contenido principal
       </a>
-      <header className="auth-layout__header flex items-center justify-between px-6 py-3 border-b">
-        <span className="font-semibold" aria-hidden="true">
-          Let Me Out
-        </span>
-        <AppNav user={user} />
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-muted-foreground" aria-label={`Usuario: ${user.name}`}>
-            {user.name}
-          </span>
-          <LogoutButton />
-        </div>
-      </header>
-      <main id="main-content" className="auth-layout__content">
+      <AppSidebar user={user} />
+      <main id="main-content" className="auth-layout__content flex-1 overflow-auto">
         <Outlet />
       </main>
     </div>


### PR DESCRIPTION
## Summary
- Replaces the authenticated header navigation with a left collapsible sidebar and updates the auth layout to a row-based structure.
- Persists sidebar collapsed state in localStorage (`sidebar-collapsed`) and keeps accessibility support via ARIA attributes and titles in collapsed mode.
- Removes `Solicitar ausencia` from navigation links while preserving dashboard CTA behavior, and adds focused tests for sidebar behavior and nav link expectations.

## Validation
- `pnpm --filter @repo/web test -- src/components/layout/AppNav.test.tsx src/components/layout/AppSidebar.test.tsx src/components/layout/LogoutButton.test.tsx`
- `pnpm exec eslint` on changed layout/navigation files

Refs: #276