### PR TITLE
fix(absence): Converts datetime-local values before absence creation

### DIFF
--- a/apps/web/src/components/absences/AbsenceFormDialog.test.tsx
+++ b/apps/web/src/components/absences/AbsenceFormDialog.test.tsx
@@ -96,6 +96,55 @@ function renderDialog(props: Partial<Parameters<typeof AbsenceFormDialog>[0]> = 
 }
 
 describe('AbsenceFormDialog', () => {
+  it('envía startAt y endAt en formato ISO 8601 UTC al crear una ausencia', async () => {
+    const user = userEvent.setup();
+    let capturedPayload: Record<string, unknown> | null = null;
+
+    server.use(
+      http.post('*/absences', async ({ request }) => {
+        capturedPayload = (await request.json()) as Record<string, unknown>;
+        return HttpResponse.json(
+          {
+            id: '01900000-0000-7000-8000-000000000999',
+            absenceTypeId: '01900000-0000-7000-8000-000000000001',
+            userId: '01900000-0000-7000-8000-000000000500',
+            startAt: '2026-03-09T13:30:00.000Z',
+            endAt: '2026-03-09T15:30:00.000Z',
+            status: 'PENDING',
+            createdAt: '2026-03-01T12:00:00.000Z',
+            updatedAt: '2026-03-01T12:00:00.000Z',
+          },
+          { status: 201 }
+        );
+      })
+    );
+
+    const { onSuccess, onOpenChange } = renderDialog();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Tipo de ausencia')).toBeInTheDocument();
+    });
+
+    const absenceTypeCombobox = screen.getByRole('combobox', { name: 'Tipo de ausencia' });
+    await user.click(absenceTypeCombobox);
+    const typeOption = await screen.findByRole('option', { name: mockAbsenceTypes[0].name });
+    await user.click(typeOption);
+
+    await user.type(screen.getByLabelText('Fecha y hora de inicio'), '2026-03-09T14:30');
+    await user.type(screen.getByLabelText('Fecha y hora de fin'), '2026-03-09T16:30');
+    await user.click(screen.getByRole('button', { name: 'Crear ausencia' }));
+
+    await waitFor(() => {
+      expect(capturedPayload).not.toBeNull();
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    expect(capturedPayload).not.toBeNull();
+    expect(capturedPayload?.['startAt']).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    expect(capturedPayload?.['endAt']).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  });
+
   it('muestra el formulario de creación de ausencia con todos los campos requeridos', async () => {
     renderDialog();
 

--- a/apps/web/src/components/absences/AbsenceFormDialog.tsx
+++ b/apps/web/src/components/absences/AbsenceFormDialog.tsx
@@ -3,7 +3,7 @@ import { isAxiosError } from 'axios';
 import { useForm, Controller } from 'react-hook-form';
 import { z } from 'zod';
 
-import { CreateAbsenceSchema, UserRole } from '@repo/types';
+import { UserRole } from '@repo/types';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -25,7 +25,26 @@ import { useAbsenceTypes } from '../../hooks/use-absence-types';
 import { useUsers } from '../../hooks/use-users';
 import { useCreateAbsence } from '../../hooks/use-absences';
 
-type FormValues = z.infer<typeof CreateAbsenceSchema>;
+const LocalDateTimeSchema = z
+  .string()
+  .min(1, 'La fecha y hora es obligatoria.')
+  .refine((value) => !Number.isNaN(new Date(value).getTime()), {
+    message: 'La fecha y hora no es válida.',
+  });
+
+const AbsenceFormSchema = z
+  .object({
+    absenceTypeId: z.string().uuid('El tipo de ausencia no es válido.'),
+    startAt: LocalDateTimeSchema,
+    endAt: LocalDateTimeSchema,
+    validatorIds: z.array(z.string().uuid()).optional(),
+  })
+  .refine((data) => Date.parse(data.endAt) > Date.parse(data.startAt), {
+    message: 'La fecha de fin debe ser posterior a la de inicio.',
+    path: ['endAt'],
+  });
+
+type FormValues = z.infer<typeof AbsenceFormSchema>;
 
 interface AbsenceFormDialogProps {
   open: boolean;
@@ -47,7 +66,7 @@ export function AbsenceFormDialog({ open, onOpenChange, onSuccess }: AbsenceForm
     formState: { errors, isSubmitting },
     setError,
   } = useForm<FormValues>({
-    resolver: zodResolver(CreateAbsenceSchema),
+    resolver: zodResolver(AbsenceFormSchema),
     defaultValues: {
       validatorIds: [],
     },
@@ -61,11 +80,19 @@ export function AbsenceFormDialog({ open, onOpenChange, onSuccess }: AbsenceForm
   );
 
   const onSubmit = async (data: FormValues) => {
+    const startAtDate = new Date(data.startAt);
+    const endAtDate = new Date(data.endAt);
+
+    if (Number.isNaN(startAtDate.getTime()) || Number.isNaN(endAtDate.getTime())) {
+      setError('root', { message: 'La fecha y hora introducida no es válida.' });
+      return;
+    }
+
     try {
       await createAbsence.mutateAsync({
         absenceTypeId: data.absenceTypeId,
-        startAt: data.startAt,
-        endAt: data.endAt,
+        startAt: startAtDate.toISOString(),
+        endAt: endAtDate.toISOString(),
         ...(data.validatorIds &&
           data.validatorIds.length > 0 && { validatorIds: data.validatorIds }),
       });

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -14,3 +14,4 @@ Element.prototype.hasPointerCapture = function () {
 
 Element.prototype.releasePointerCapture = function () {};
 Element.prototype.setPointerCapture = function () {};
+Element.prototype.scrollIntoView = function () {};


### PR DESCRIPTION
## Summary
- fixes the "Invalid date" create-absence failure by using a form-specific schema for `datetime-local` values while preserving submit-time validation
- converts `startAt` and `endAt` to full UTC ISO 8601 strings in `AbsenceFormDialog` before calling the create absence mutation
- adds a submit test that verifies the payload sends ISO timestamps (`...Z`) for both date fields
- adds a `scrollIntoView` test polyfill used by Radix Select in JSDOM

## Validation
- pnpm --filter @repo/web test -- src/components/absences/AbsenceFormDialog.test.tsx

## Issue 278 Acceptance Criteria
- [x] Absences can be created from the form without any "Invalid date" validation error.
- [x] `startAt` and `endAt` are sent to the backend as full ISO 8601 UTC strings.
- [x] Conversion is applied in the `onSubmit` handler of `AbsenceFormDialog.tsx`.
- [x] `AbsenceFormDialog.test.tsx` verifies ISO 8601 UTC format for submitted values.
- [x] Calendar/dashboard date display verified; no extra utility required.

Closes #278